### PR TITLE
feat: implement minimize popup option

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -32,7 +32,8 @@ This document provides a comprehensive list of features for the YouTube Music + 
 - **Screens**:
     - **Playlist Selection Screen**: Grid of playlists with thumbnails and track counts.
     - **Playlist Details Screen**: Active workspace for a selected playlist.
-- **Testable Case**: Verify navigation between selection and details screens using the "Back" button.
+- **Minimize Option**: A "−" button in the header to collapse the popup to the bottom-right corner, allowing continued interaction with the page.
+- **Testable Case**: Verify navigation between selection and details screens using the "Back" button; verify the popup minimizes and restores correctly.
 
 ### 1.5 Settings/Options Page
 - **Feature**: A dedicated page for user preferences.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -19,3 +19,7 @@ Follow the coding style guidelines below when modifying or adding to the codebas
 - **Semantic Structure:** Use semantic and accessible HTML elements to build layouts.
 - **Templates Over Imperative UI:** Prefer static HTML templates for building user interfaces. It is easier to read and maintain an HTML file than tracking elements built entirely in a JavaScript function.
 - **Clean Markup:** Do not use inline styles or inline JavaScript (`onclick="..."`) attributes within the HTML elements.
+
+## UI & State Management
+- **Minimized State:** When implementing "minimize" or "collapse" functionality, use a top-level CSS class (e.g., `.minimized`) on the container. Ensure that clicking the header or a dedicated toggle button restores the state using a centralized `toggleMinimize` method.
+- **Event Delegation:** Prefer adding listeners to parent containers (like the popup header) for actions that should apply to the whole component state.

--- a/html/in-site-popup.html
+++ b/html/in-site-popup.html
@@ -7,6 +7,7 @@
             <h2 id="popupTitle"></h2>
             <div class="header-actions-wrapper">
                 <a href="https://chromewebstore.google.com/detail/lkieghnbgfnidfhdeclkjkmnjokmkmdc/support" target="_blank" rel="noopener noreferrer" class="report-issue-link">Report a problem</a>
+                <button id="minimizePopupBtn" class="minimize-btn" aria-label="Minimize popup">−</button>
                 <button id="closePopupBtn" class="close-btn" aria-label="Close popup">×</button>
             </div>
         </div>

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -352,7 +352,7 @@ import { TrackProcessor } from './track-processor.js';
 
         popupElement?.addEventListener('click', (event) => {
           if (event.target === popupElement) {
-            this.hidePopup();
+            this.toggleMinimize();
           }
         });
 

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -273,8 +273,32 @@ import { TrackProcessor } from './track-processor.js';
       const popupElement = document.getElementById('yt-music-plus-popup');
       if (popupElement) {
         popupElement.classList.add('hidden');
+        // Reset minimized state when closing
+        const popupContainer = popupElement.querySelector('.yt-music-extended-popup-container');
+        if (popupContainer?.classList.contains('minimized')) {
+          this.toggleMinimize();
+        }
       }
       this.enableReload();
+    }
+
+    /**
+     * Toggles popup minimization
+     */
+    toggleMinimize() {
+      const popupHolder = document.getElementById('yt-music-plus-popup');
+      const popupContainer = popupHolder?.querySelector('.yt-music-extended-popup-container');
+      const minimizeBtn = popupHolder?.querySelector('#minimizePopupBtn');
+
+      if (popupHolder && popupContainer) {
+        const isMinimized = popupContainer.classList.toggle('minimized');
+        popupHolder.classList.toggle('minimized', isMinimized);
+        
+        if (minimizeBtn) {
+          minimizeBtn.textContent = isMinimized ? '+' : '−';
+          minimizeBtn.setAttribute('aria-label', isMinimized ? 'Restore popup' : 'Minimize popup');
+        }
+      }
     }
 
     /**
@@ -307,6 +331,24 @@ import { TrackProcessor } from './track-processor.js';
       const closeBtn = popupElement?.querySelector('#closePopupBtn');
       if (closeBtn) {
         closeBtn.addEventListener('click', () => this.hidePopup());
+
+        const minimizeBtn = popupElement?.querySelector('#minimizePopupBtn');
+        if (minimizeBtn) {
+          minimizeBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.toggleMinimize();
+          });
+        }
+
+        const header = popupElement?.querySelector('.popup-header');
+        if (header) {
+          header.addEventListener('click', () => {
+            const popupContainer = popupElement.querySelector('.yt-music-extended-popup-container');
+            if (popupContainer?.classList.contains('minimized')) {
+              this.toggleMinimize();
+            }
+          });
+        }
 
         popupElement?.addEventListener('click', (event) => {
           if (event.target === popupElement) {

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -192,12 +192,36 @@ import { TrackProcessor } from './track-processor.js';
         showNavButton: true
       };
       
+      // Cache for popup elements
+      this.popupElements = {
+        holder: null,
+        container: null,
+        minimizeBtn: null,
+        header: null
+      };
+      
       this.preventUnloadListener = (e) => {
         if (this.isReloadDisabled) {
           e.preventDefault();
           e.returnValue = '';
         }
       };
+    }
+
+    /**
+     * Caches popup-related DOM elements
+     */
+    cachePopupElements() {
+      if (this.popupElements.holder) return true;
+
+      this.popupElements.holder = document.getElementById('yt-music-plus-popup');
+      if (this.popupElements.holder) {
+        this.popupElements.container = this.popupElements.holder.querySelector('.yt-music-extended-popup-container');
+        this.popupElements.minimizeBtn = this.popupElements.holder.querySelector('#minimizePopupBtn');
+        this.popupElements.header = this.popupElements.holder.querySelector('.popup-header');
+        return true;
+      }
+      return false;
     }
 
     get cancelSearch() {
@@ -250,9 +274,8 @@ import { TrackProcessor } from './track-processor.js';
      * Shows popup and loads playlist data
      */
     async showPopup() {
-      const popupElement = document.getElementById('yt-music-plus-popup');
-      if (popupElement) {
-        popupElement.classList.remove('hidden');
+      if (this.cachePopupElements()) {
+        this.popupElements.holder.classList.remove('hidden');
       }
 
       await this.initPlaylistFetching();
@@ -270,12 +293,10 @@ import { TrackProcessor } from './track-processor.js';
      * Hides popup and re-enables page reload
      */
     hidePopup() {
-      const popupElement = document.getElementById('yt-music-plus-popup');
-      if (popupElement) {
-        popupElement.classList.add('hidden');
+      if (this.cachePopupElements()) {
+        this.popupElements.holder.classList.add('hidden');
         // Reset minimized state when closing
-        const popupContainer = popupElement.querySelector('.yt-music-extended-popup-container');
-        if (popupContainer?.classList.contains('minimized')) {
+        if (this.popupElements.container?.classList.contains('minimized')) {
           this.toggleMinimize();
         }
       }
@@ -286,13 +307,13 @@ import { TrackProcessor } from './track-processor.js';
      * Toggles popup minimization
      */
     toggleMinimize() {
-      const popupHolder = document.getElementById('yt-music-plus-popup');
-      const popupContainer = popupHolder?.querySelector('.yt-music-extended-popup-container');
-      const minimizeBtn = popupHolder?.querySelector('#minimizePopupBtn');
+      if (!this.cachePopupElements()) return;
 
-      if (popupHolder && popupContainer) {
-        const isMinimized = popupContainer.classList.toggle('minimized');
-        popupHolder.classList.toggle('minimized', isMinimized);
+      const { holder, container, minimizeBtn } = this.popupElements;
+      
+      if (holder && container) {
+        const isMinimized = container.classList.toggle('minimized');
+        holder.classList.toggle('minimized', isMinimized);
         
         if (minimizeBtn) {
           minimizeBtn.textContent = isMinimized ? '+' : '−';
@@ -326,38 +347,43 @@ import { TrackProcessor } from './track-processor.js';
         navBarBtn.addEventListener('click', () => this.showPopup());
       }
 
-      // Popup close listeners
-      const popupElement = document.getElementById('yt-music-plus-popup');
-      const closeBtn = popupElement?.querySelector('#closePopupBtn');
-      if (closeBtn) {
-        closeBtn.addEventListener('click', () => this.hidePopup());
+      // Popup close and state listeners
+      if (this.cachePopupElements()) {
+        const { holder, container, header } = this.popupElements;
 
-        const minimizeBtn = popupElement?.querySelector('#minimizePopupBtn');
-        if (minimizeBtn) {
-          minimizeBtn.addEventListener('click', (e) => {
+        // Use event delegation for header actions (close, minimize, restore)
+        header?.addEventListener('click', (e) => {
+          const target = e.target;
+          
+          // Handle close button
+          if (target.id === 'closePopupBtn' || target.closest('#closePopupBtn')) {
+            this.hidePopup();
+            return;
+          }
+
+          // Handle minimize button
+          if (target.id === 'minimizePopupBtn' || target.closest('#minimizePopupBtn')) {
             e.stopPropagation();
             this.toggleMinimize();
-          });
-        }
+            return;
+          }
 
-        const header = popupElement?.querySelector('.popup-header');
-        if (header) {
-          header.addEventListener('click', () => {
-            const popupContainer = popupElement.querySelector('.yt-music-extended-popup-container');
-            if (popupContainer?.classList.contains('minimized')) {
-              this.toggleMinimize();
-            }
-          });
-        }
+          // Restore on header click if minimized
+          // Ensure we didn't click other interactive elements like links
+          if (container.classList.contains('minimized') && !target.closest('a')) {
+            this.toggleMinimize();
+          }
+        });
 
-        popupElement?.addEventListener('click', (event) => {
-          if (event.target === popupElement) {
+        // Backdrop click handler
+        holder.addEventListener('click', (e) => {
+          if (e.target === holder) {
             this.toggleMinimize();
           }
         });
 
         document.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape' && !popupElement?.classList.contains('hidden')) {
+          if (e.key === 'Escape' && !holder.classList.contains('hidden')) {
             this.hidePopup();
           }
         });

--- a/styles/in-site-popup.css
+++ b/styles/in-site-popup.css
@@ -146,6 +146,10 @@
     box-shadow: none;
 }
 
+.yt-music-extended-popup-container.minimized .report-issue-link {
+    display: none !important;
+}
+
 .yt-music-extended-popup-container.minimized .extension-branding-title {
     font-size: 14px;
 }

--- a/styles/in-site-popup.css
+++ b/styles/in-site-popup.css
@@ -82,7 +82,7 @@
     margin-bottom: 12px;
 }
 
-.close-btn {
+.close-btn, .minimize-btn {
     background: none;
     border: none;
     font-size: 28px;
@@ -95,14 +95,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
-border-radius: 0;
+    border-radius: 0;
     transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
-.close-btn:hover {
+.close-btn:hover, .minimize-btn:hover {
     background-color: #f0f0f0;
     color: #333;
     transform: translateY(-1px);
+}
+
+.minimize-btn {
+    font-size: 24px;
 }
 
 .report-issue-link {
@@ -115,8 +119,52 @@ border-radius: 0;
     text-decoration: none;
 }
 
-.close-btn:active {
+.close-btn:active, .minimize-btn:active {
     background-color: #e0e0e0;
+}
+
+/* Minimized state */
+.yt-music-extended-popup-container.minimized {
+    top: auto;
+    left: auto;
+    bottom: 20px;
+    right: 20px;
+    transform: none;
+    width: 350px;
+    height: auto;
+    max-height: 60px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+    border: 1px solid #e0e0e0;
+}
+
+.yt-music-extended-popup-container.minimized .yt-music-extended-popup-content > *:not(.popup-header) {
+    display: none !important;
+}
+
+.yt-music-extended-popup-container.minimized .popup-header {
+    padding: 8px 16px;
+    box-shadow: none;
+}
+
+.yt-music-extended-popup-container.minimized .extension-branding-title {
+    font-size: 14px;
+}
+
+.yt-music-extended-popup-container.minimized #popupTitle {
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 120px;
+}
+
+.yt-music-extended-popup-container-holder.minimized {
+    background-color: transparent;
+    pointer-events: none;
+}
+
+.yt-music-extended-popup-container-holder.minimized .yt-music-extended-popup-container {
+    pointer-events: auto;
 }
 
 /* Playlist Info Section */

--- a/tests/html/templates.test.js
+++ b/tests/html/templates.test.js
@@ -58,4 +58,10 @@ describe('In-Site Popup HTML Templates', () => {
     expect(content.querySelector('.content-wrapper')).not.toBeNull();
     expect(content.querySelector('.icon')).not.toBeNull();
   });
+
+  it('should have the minimize button in the popup header', () => {
+    const minimizeBtn = document.getElementById('minimizePopupBtn');
+    expect(minimizeBtn).not.toBeNull();
+    expect(minimizeBtn.getAttribute('aria-label')).toBe('Minimize popup');
+  });
 });


### PR DESCRIPTION
## Changes
- Added a minimize button to the in-site popup header.
- Implemented a minimized state that collapses the popup to the bottom-right corner.
- Changed backdrop click behavior to minimize the popup instead of closing it.
- Hidden 'Report a problem' link in minimized view for a cleaner UI.
- Updated  and  with the new functionality and design patterns.
- Added test coverage for the new UI element.

## How to test
1. Open the YouTube Music + popup.
2. Click the '−' button to minimize.
3. Click the header or the '+' button to restore.
4. Click outside the popup (on the dimmed backdrop) to verify it minimizes.
5. Verify the 'Report a problem' link is hidden while minimized.