### PR TITLE
feat: add playback controls to popup media grid items

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -114,6 +114,12 @@ This document provides a comprehensive list of features for the YouTube Music + 
 - **Cancellation**: A "Cancel Search" button to stop ongoing API operations.
 - **Testable Case**: Start a large scan; click "Cancel"; verify processing stops immediately.
 
+### 3.6 Integrated Track Playback
+- **Feature**: Playback controls (Play, Pause, Seek forward/backward 10s) integrated into the media grid.
+- **Behavior**: Controls appear as an overlay when hovering over the track details section (Original or Replacement media).
+- **Control**: Allows users to preview tracks directly within the popup without navigating away from the current workspace.
+- **Testable Case**: Hover over a track title in the grid; verify playback controls appear and function as expected (controlling the page's background player).
+
 ---
 
 ## 4. Safety & Reliability Features

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -20,6 +20,9 @@ Follow the coding style guidelines below when modifying or adding to the codebas
 - **Templates Over Imperative UI:** Prefer static HTML templates for building user interfaces. It is easier to read and maintain an HTML file than tracking elements built entirely in a JavaScript function.
 - **Clean Markup:** Do not use inline styles or inline JavaScript (`onclick="..."`) attributes within the HTML elements.
 
+## Documentation & Feature Tracking
+- **Update Features List:** Always update `FEATURES.md` whenever a new feature is implemented or an existing feature's behavior is significantly changed. This ensures the features list remains a single source of truth for testing and documentation.
+
 ## UI & State Management
 - **Minimized State:** When implementing "minimize" or "collapse" functionality, use a top-level CSS class (e.g., `.minimized`) on the container. Ensure that clicking the header or a dedicated toggle button restores the state using a centralized `toggleMinimize` method.
 - **Event Delegation:** Prefer adding listeners to parent containers (like the popup header) for actions that should apply to the whole component state.

--- a/html/in-site-popup.html
+++ b/html/in-site-popup.html
@@ -135,6 +135,12 @@
                 <a class="media-link" target="_blank" rel="noopener noreferrer">
                     <span class="link-icon">🔗 Link</span>
                 </a>
+                <div class="yt-music-plus-controls hidden">
+                    <button class="yt-music-plus-control-btn btn-seek-back" title="Seek back 10s">⟲</button>
+                    <button class="yt-music-plus-control-btn btn-play" title="Play">▶</button>
+                    <button class="yt-music-plus-control-btn btn-pause" title="Pause">⏸</button>
+                    <button class="yt-music-plus-control-btn btn-seek-forward" title="Seek forward 10s">⟳</button>
+                </div>
             </div>
         </div>
     </template>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Music +",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "action": {
     "default_popup": "popup/popup.html",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Music +",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "action": {
     "default_popup": "popup/popup.html",
@@ -45,6 +45,7 @@
         "scripts/bridge.js",
         "scripts/bridge-ui.js",
         "scripts/track-processor.js",
+        "scripts/player-handler.js",
         "scripts/yt-music-api.js",
         "scripts/yt-music-parser.js",
         "scripts/models/playlist.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-music-plus",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-music-plus",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "type": "module",
   "scripts": {

--- a/scripts/bridge-ui.js
+++ b/scripts/bridge-ui.js
@@ -49,7 +49,7 @@ export class BridgeUI {
   addItem(item, baseUrl, index) {
     const { originalMedia, replacementMedia } = this.bridge._createMediaObjects(item, baseUrl);
 
-    const gridRow = MediaGridRow.render(originalMedia, replacementMedia, index);
+    const gridRow = MediaGridRow.render(originalMedia, replacementMedia, index, this.bridge.playerHandler);
     document.getElementById('yt-music-plus-itemsGridContainer')?.appendChild(gridRow);
     this.rowMap.set(index, gridRow);
   }
@@ -65,7 +65,7 @@ export class BridgeUI {
       const wasChecked = oldCheckbox ? oldCheckbox.checked : false;
 
       const { originalMedia, replacementMedia } = this.bridge._createMediaObjects(item, baseUrl);
-      const newRow = MediaGridRow.render(originalMedia, replacementMedia, index);
+      const newRow = MediaGridRow.render(originalMedia, replacementMedia, index, this.bridge.playerHandler);
       
       const newCheckbox = newRow.querySelector('.item-checkbox');
       if (newCheckbox && oldCheckbox && userInteracted) {

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -7,6 +7,7 @@ import { YTMusicAPI } from './yt-music-api.js';
 import { UIHelper } from '../utils/ui-helper.js';
 import { BridgeUI } from './bridge-ui.js';
 import { TrackProcessor } from './track-processor.js';
+import { PlayerHandler } from './player-handler.js';
 
 (function () {
   /**
@@ -180,6 +181,7 @@ import { TrackProcessor } from './track-processor.js';
       this.ytMusicAPI = new YTMusicAPI();
       this.ui = new BridgeUI(this);
       this.processor = new TrackProcessor(this);
+      this.playerHandler = new PlayerHandler();
       this.session = new SearchSession();
       
       this.currentSelectedPlaylist = null;
@@ -268,6 +270,7 @@ import { TrackProcessor } from './track-processor.js';
       this.addEventListeners();
       this.ui.injectActionButtons(this.extSettings);
       this.ui.showTriggerButtons(this.extSettings);
+      this.playerHandler.init();
     }
 
     /**

--- a/scripts/player-handler.js
+++ b/scripts/player-handler.js
@@ -4,9 +4,18 @@
  */
 export class PlayerHandler {
   constructor() {
-    this.app = document.querySelector('ytmusic-app');
-    this.playerApi = this.app?.playerApi;
     this.initialized = false;
+    this.retryCount = 0;
+    this.maxRetries = 10;
+  }
+
+  /**
+   * Centralized getter for the player API
+   * @returns {Object|null}
+   */
+  get api() {
+    const app = document.querySelector('ytmusic-app');
+    return app?.playerApi || null;
   }
 
   /**
@@ -15,43 +24,41 @@ export class PlayerHandler {
   init() {
     if (this.initialized) return;
     
-    this.app = document.querySelector('ytmusic-app');
-    this.playerApi = this.app?.playerApi;
-    
-    if (!this.playerApi) {
-      // Retry after a short delay if playerApi is not yet available
-      setTimeout(() => this.init(), 1000);
+    if (!this.api) {
+      if (this.retryCount < this.maxRetries) {
+        this.retryCount++;
+        setTimeout(() => this.init(), 1000);
+      } else {
+        console.error('PlayerHandler: Failed to initialize after max retries.');
+      }
       return;
     }
 
     this.initialized = true;
+    this.retryCount = 0;
   }
 
   /**
    * Playback actions
    */
   playTrack(videoId) {
-    if (!this.playerApi) {
-      this.app = document.querySelector('ytmusic-app');
-      this.playerApi = this.app?.playerApi;
-    }
-    
-    if (!this.playerApi) return;
+    const playerApi = this.api;
+    if (!playerApi) return;
     
     // Check if it's already the current video
-    const currentVideoId = this.playerApi.getVideoData()?.video_id;
+    const currentVideoId = playerApi.getVideoData()?.video_id;
     if (currentVideoId === videoId) {
-      this.playerApi.playVideo();
+      playerApi.playVideo();
     } else {
-      this.playerApi.loadVideoById(videoId);
+      playerApi.loadVideoById(videoId);
     }
   }
 
   pauseTrack() {
-    this.playerApi?.pauseVideo();
+    this.api?.pauseVideo();
   }
 
   seekBy(seconds) {
-    this.playerApi?.seekBy(seconds);
+    this.api?.seekBy(seconds);
   }
 }

--- a/scripts/player-handler.js
+++ b/scripts/player-handler.js
@@ -1,0 +1,57 @@
+/**
+ * PlayerHandler - Handles playback controls within the YouTube Music UI
+ * Provides play, pause, and seek functionality for each track
+ */
+export class PlayerHandler {
+  constructor() {
+    this.app = document.querySelector('ytmusic-app');
+    this.playerApi = this.app?.playerApi;
+    this.initialized = false;
+  }
+
+  /**
+   * Initializes the PlayerHandler
+   */
+  init() {
+    if (this.initialized) return;
+    
+    this.app = document.querySelector('ytmusic-app');
+    this.playerApi = this.app?.playerApi;
+    
+    if (!this.playerApi) {
+      // Retry after a short delay if playerApi is not yet available
+      setTimeout(() => this.init(), 1000);
+      return;
+    }
+
+    this.initialized = true;
+  }
+
+  /**
+   * Playback actions
+   */
+  playTrack(videoId) {
+    if (!this.playerApi) {
+      this.app = document.querySelector('ytmusic-app');
+      this.playerApi = this.app?.playerApi;
+    }
+    
+    if (!this.playerApi) return;
+    
+    // Check if it's already the current video
+    const currentVideoId = this.playerApi.getVideoData()?.video_id;
+    if (currentVideoId === videoId) {
+      this.playerApi.playVideo();
+    } else {
+      this.playerApi.loadVideoById(videoId);
+    }
+  }
+
+  pauseTrack() {
+    this.playerApi?.pauseVideo();
+  }
+
+  seekBy(seconds) {
+    this.playerApi?.seekBy(seconds);
+  }
+}

--- a/styles/in-site-popup.css
+++ b/styles/in-site-popup.css
@@ -506,6 +506,7 @@
     gap: 2px;
     flex: 1;
     min-width: 0;
+    position: relative;
 }
 
 .media-title {
@@ -982,4 +983,59 @@
 
 .footer-left .search-progress {
     margin-left: 0;
+}
+
+/* Player Controls on Hover */
+.yt-music-plus-controls {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(255, 255, 255, 0.9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    z-index: 10;
+}
+
+.media-info:hover .yt-music-plus-controls {
+    opacity: 1;
+}
+
+.yt-music-plus-control-btn {
+    background: none;
+    border: none;
+    color: black;
+    cursor: pointer;
+    padding: 4px;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.1s ease, background-color 0.1s ease;
+    border-radius: 50%;
+    width: 32px;
+    height: 32px;
+}
+
+.yt-music-plus-control-btn:hover {
+    transform: scale(1.1);
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.yt-music-plus-control-btn.btn-play {
+    font-size: 20px;
+}
+
+.yt-music-plus-control-btn.btn-pause {
+    font-size: 14px;
+}
+
+.yt-music-plus-control-btn.btn-seek-back,
+.yt-music-plus-control-btn.btn-seek-forward {
+    font-size: 18px;
 }

--- a/tests/scripts/player-handler.test.js
+++ b/tests/scripts/player-handler.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PlayerHandler } from '../../scripts/player-handler.js';
+
+describe('PlayerHandler', () => {
+  let handler;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Clean up document body
+    document.body.innerHTML = '';
+    handler = new PlayerHandler();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should initialize successfully when playerApi is available', () => {
+    const mockApi = { playVideo: vi.fn() };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    handler.init();
+    expect(handler.initialized).toBe(true);
+    expect(handler.api).toBe(mockApi);
+  });
+
+  it('should retry initialization if playerApi is not immediately available', () => {
+    handler.init();
+    expect(handler.initialized).toBe(false);
+    expect(handler.retryCount).toBe(1);
+
+    // Add mock app after first try
+    const mockApi = { playVideo: vi.fn() };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    vi.advanceTimersByTime(1000);
+    expect(handler.initialized).toBe(true);
+    expect(handler.retryCount).toBe(0);
+  });
+
+  it('should stop retrying after maxRetries', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    
+    handler.init();
+    for (let i = 0; i < 10; i++) {
+      vi.advanceTimersByTime(1000);
+    }
+
+    expect(handler.initialized).toBe(false);
+    expect(handler.retryCount).toBe(10);
+    expect(consoleSpy).toHaveBeenCalledWith('PlayerHandler: Failed to initialize after max retries.');
+  });
+
+  it('should call playVideo when playTrack is called with current videoId', () => {
+    const mockApi = { 
+      getVideoData: vi.fn().mockReturnValue({ video_id: 'vid123' }),
+      playVideo: vi.fn(),
+      loadVideoById: vi.fn()
+    };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    handler.playTrack('vid123');
+    expect(mockApi.playVideo).toHaveBeenCalled();
+    expect(mockApi.loadVideoById).not.toHaveBeenCalled();
+  });
+
+  it('should call loadVideoById when playTrack is called with different videoId', () => {
+    const mockApi = { 
+      getVideoData: vi.fn().mockReturnValue({ video_id: 'other123' }),
+      playVideo: vi.fn(),
+      loadVideoById: vi.fn()
+    };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    handler.playTrack('vid123');
+    expect(mockApi.loadVideoById).toHaveBeenCalledWith('vid123');
+  });
+
+  it('should call pauseVideo', () => {
+    const mockApi = { pauseVideo: vi.fn() };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    handler.pauseTrack();
+    expect(mockApi.pauseVideo).toHaveBeenCalled();
+  });
+
+  it('should call seekBy', () => {
+    const mockApi = { seekBy: vi.fn() };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    handler.seekBy(10);
+    expect(mockApi.seekBy).toHaveBeenCalledWith(10);
+  });
+});

--- a/utils/ui-helper.js
+++ b/utils/ui-helper.js
@@ -7,9 +7,10 @@ export class MediaItem {
   /**
    * Build a DOM fragment representing a track/item from a media object.
    * @param {Object} media
+   * @param {Object} [playerHandler]
    * @returns {HTMLElement}
    */
-  static render(media = {}) {
+  static render(media = {}, playerHandler = null) {
     const template = document.getElementById('yt-music-plus-media-item-template');
     if (!template) {
       throw new Error('Template "yt-music-plus-media-item-template" not found');
@@ -21,11 +22,35 @@ export class MediaItem {
     const title = item.querySelector('.media-title');
     const artist = item.querySelector('.media-artist');
     const link = item.querySelector('.media-link');
+    const controls = item.querySelector('.yt-music-plus-controls');
 
     if (media.thumbnail) {
       thumb.src = media.thumbnail;
     } else {
       thumb.remove();
+    }
+
+    // Setup player controls if playerHandler and videoId are provided
+    if (playerHandler && media.videoId && controls) {
+      controls.classList.remove('hidden');
+      
+      const bindControl = (selector, action) => {
+        const btn = controls.querySelector(selector);
+        if (btn) {
+          btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            action();
+          });
+        }
+      };
+
+      bindControl('.btn-play', () => playerHandler.playTrack(media.videoId));
+      bindControl('.btn-pause', () => playerHandler.pauseTrack());
+      bindControl('.btn-seek-back', () => playerHandler.seekBy(-10));
+      bindControl('.btn-seek-forward', () => playerHandler.seekBy(10));
+    } else {
+      controls?.remove();
     }
 
     title.textContent = media.name || 'Unknown Title';
@@ -57,9 +82,10 @@ export class MediaGridRow {
    * @param {Object} originalMedia
    * @param {Object} replacementMedia
    * @param {number} [serialNumber=1]
+   * @param {Object} [playerHandler=null]
    * @returns {HTMLElement}
    */
-  static render(originalMedia, replacementMedia, serialNumber = 1) {
+  static render(originalMedia, replacementMedia, serialNumber = 1, playerHandler = null) {
     const template = document.getElementById('yt-music-plus-grid-row-template');
     if (!template) {
       throw new Error('Template "yt-music-plus-grid-row-template" not found');
@@ -101,14 +127,14 @@ export class MediaGridRow {
     }
     const originalCol = row.querySelector('.grid-col-original');
     originalCol.addEventListener('click', (e) => {
-      if (e.target.closest('a')) return;
+      if (e.target.closest('a') || e.target.closest('.yt-music-plus-control-btn')) return;
       if (!checkbox.disabled) {
         checkbox.checked = !checkbox.checked;
         checkbox.dataset.userInteracted = 'true';
         checkbox.dispatchEvent(new Event('change', { bubbles: true }));
       }
     });
-    originalCol.appendChild(MediaItem.render(originalMedia));
+    originalCol.appendChild(MediaItem.render(originalMedia, playerHandler));
 
     const replacementCol = row.querySelector('.grid-col-replacement');
     if (replacementMedia && replacementMedia.isGoodMatch === false) {
@@ -117,7 +143,8 @@ export class MediaGridRow {
     }
     replacementCol.appendChild(
       MediaItem.render(
-        replacementMedia || { name: 'No replacement found' }
+        replacementMedia || { name: 'No replacement found' },
+        playerHandler
       )
     );
 


### PR DESCRIPTION
This PR implements playback controls (play, pause, and 10s seek) directly within the media grid items of the extension's popup.

### Key Changes:
- **New PlayerHandler**: Manages interaction with the YouTube Music `playerApi`.
- **Integrated Controls**: Playback buttons are now part of the `yt-music-plus-media-item-template`.
- **Dynamic Binding**: Events are bound during row creation in `MediaItem.render`.
- **UI/UX**: Controls appear as a light overlay on hover over the track details section.
- **Robustness**: Prevents accidental checkbox toggling when interacting with playback buttons.