### PR TITLE
feat: add 'Load All Playlists' and improve editability detection

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -40,6 +40,7 @@ This document provides a comprehensive list of features for the YouTube Music + 
 - **Options**:
     - Toggle Navigation Button.
     - Toggle Playlist Page Button.
+    - **Always load all playlists**: When enabled, the extension fetches all playlists from the user's library by default instead of only editable ones.
     - Reset "Hide Warning Message" state.
     - Save/Reset to Defaults buttons.
 - **Testable Case**: Change a setting, save, and verify the UI updates accordingly on music.youtube.com.
@@ -49,9 +50,12 @@ This document provides a comprehensive list of features for the YouTube Music + 
 ## 2. Core Functionalities
 
 ### 2.1 Playlist Discovery & Sync
-- **Feature**: Automatically fetches all editable playlists from the user's account.
-- **Behavior**: Includes a "Refresh Playlists" button to force a re-fetch.
-- **Testable Case**: Click "Refresh Playlists" and verify the list updates.
+- **Feature**: Automatically fetches playlists from the user's account.
+- **Refresh Options**:
+    - **Load Editable Playlists**: Re-fetches only the playlists that the user has permission to edit.
+    - **Load All Playlists**: Fetches all playlists found in the user's library, including liked playlists and albums added as playlists.
+- **Default Behavior**: Defaults to editable playlists unless "Always load all playlists" is enabled in settings.
+- **Testable Case**: Click "Load Editable Playlists" and verify only owned/editable playlists appear; click "Load All Playlists" and verify a broader set of playlists is loaded.
 
 ### 2.2 Find Unavailable Tracks
 - **Feature**: Scans the selected playlist for "greyed-out" (unavailable) tracks.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,6 +9,7 @@ Follow the coding style guidelines below when modifying or adding to the codebas
 - **Structured Functions:** Write modular, properly structured functions with a single responsibility. Use clear naming conventions and include JSDoc comments where appropriate.
 - **DOM Manipulation:** Avoid creating complex elements purely through JavaScript (e.g., long chains of `document.createElement`). If a structure can be defined in an HTML file or template, do so and inject it.
 - **Event Handling:** Avoid inline event handlers in HTML. Use `addEventListener` in JS, and leverage event delegation when handling multiple similar child elements.
+- **Constants Over Magic Literals:** Avoid using magic numbers or strings (e.g., timeout durations, retry counts, or regex patterns) directly in the code. All such literals should be defined in `utils/constants.js` and imported where needed.
 
 ## Cascading Style Sheets (CSS)
 - **No Inline CSS:** Avoid inline styles (e.g., `style="..."` or `element.style.property`) whenever possible. 

--- a/background.js
+++ b/background.js
@@ -40,6 +40,19 @@ class BackgroundService {
           sendResponse({ success: true });
           break;
 
+        case 'settingsUpdated':
+          // Broadcast settings to all YouTube Music tabs
+          chrome.tabs.query({ url: '*://music.youtube.com/*' }, (tabs) => {
+            tabs.forEach((tab) => {
+              chrome.tabs.sendMessage(tab.id, {
+                action: 'settingsUpdated',
+                settings: message.settings
+              });
+            });
+          });
+          sendResponse({ success: true });
+          break;
+
         default:
           sendResponse({ success: false, message: 'Unknown action' });
       }

--- a/html/in-site-popup.html
+++ b/html/in-site-popup.html
@@ -23,7 +23,8 @@
                 </div>
             </div>
             <div class="playlist-controls-wrapper">
-                <button id="refreshPlaylistsBtn" class="btn btn-primary" aria-label="Refresh playlists" type="button">Refresh Playlists</button>
+                <button id="refreshPlaylistsBtn" class="btn btn-primary" aria-label="Load editable playlists" type="button" title="Load only your editable playlists">Load Editable Playlists</button>
+                <button id="loadAllPlaylistsBtn" class="btn btn-primary" aria-label="Load all playlists" type="button" title="Load all playlists from your library, including those you cannot edit">Load All Playlists</button>
             </div>
         </div>
 

--- a/options.html
+++ b/options.html
@@ -217,6 +217,14 @@
             </label>
             <p class="info-text">Adds action button on playlist pages</p>
           </div>
+
+          <div class="setting-group">
+            <label>
+              <input type="checkbox" id="loadAllPlaylists" name="loadAllPlaylists">
+              Always load all playlists
+            </label>
+            <p class="info-text">When enabled, the extension will fetch all playlists from your library by default (including non-editable ones). Default is editable playlists only.</p>
+          </div>
         </section>
 
         <div id="statusMessage" class="status-message"></div>

--- a/options.js
+++ b/options.js
@@ -12,6 +12,7 @@ class OptionsPage {
     this.defaultSettings = {
       showNavButton: true,
       showPlaylistButton: true,
+      loadAllPlaylists: false,
     };
     this.storageManager = new StorageManager();
     this.form = document.getElementById('settingsForm');

--- a/options.js
+++ b/options.js
@@ -1,19 +1,13 @@
 import { StorageManager } from './utils/storage.js';
+import { CONSTANTS } from './utils/constants.js';
 
 /**
  * OptionsPage - Manages the extension's options/settings page
  * Handles loading, saving, and resetting user preferences
  */
 class OptionsPage {
-  // Constants for UI behavior
-  static STATUS_MESSAGE_DURATION = 3000;
-
   constructor() {
-    this.defaultSettings = {
-      showNavButton: true,
-      showPlaylistButton: true,
-      loadAllPlaylists: false,
-    };
+    this.defaultSettings = CONSTANTS.SETTINGS.DEFAULT;
     this.storageManager = new StorageManager();
     this.form = document.getElementById('settingsForm');
     this.statusMessage = document.getElementById('statusMessage');
@@ -145,7 +139,7 @@ class OptionsPage {
 
     setTimeout(() => {
       this.statusMessage.classList.remove('show');
-    }, OptionsPage.STATUS_MESSAGE_DURATION);
+    }, CONSTANTS.UI.STATUS_DURATION_MS);
   }
 }
 

--- a/scripts/bridge-ui.js
+++ b/scripts/bridge-ui.js
@@ -1,5 +1,6 @@
 import { UIHelper, MediaGridRow, PlaylistCard } from '../utils/ui-helper.js';
 import { BrowserUtils } from '../utils/utils.js';
+import { CONSTANTS } from '../utils/constants.js';
 
 /**
  * BridgeUI - Handles all DOM interactions for the Bridge script within the page context
@@ -131,7 +132,7 @@ export class BridgeUI {
     if (searchInput.dataset.initialized) return;
     searchInput.dataset.initialized = 'true';
 
-    const debouncedSearch = BrowserUtils.debounce((e) => this.filterGridItems(e.target.value), 250);
+    const debouncedSearch = BrowserUtils.debounce((e) => this.filterGridItems(e.target.value), CONSTANTS.UI.DEBOUNCE_DELAY_MS);
     
     searchInput.addEventListener('input', (e) => {
       debouncedSearch(e);

--- a/scripts/bridge-ui.js
+++ b/scripts/bridge-ui.js
@@ -246,19 +246,32 @@ export class BridgeUI {
   }
 
   /**
-   * Initializes the refresh button
+   * Initializes the playlist refresh buttons
    */
   initRefreshButton() {
-    const btn = document.getElementById('refreshPlaylistsBtn');
-    if (btn && !btn.dataset.initialized) {
-      btn.dataset.initialized = 'true';
-      btn.addEventListener('click', async () => {
-        btn.disabled = true;
-        const originalText = btn.textContent;
-        btn.textContent = 'Refreshing...';
-        await this.bridge.initPlaylistFetching(true);
-        btn.disabled = false;
-        btn.textContent = originalText;
+    const refreshBtn = document.getElementById('refreshPlaylistsBtn');
+    if (refreshBtn && !refreshBtn.dataset.initialized) {
+      refreshBtn.dataset.initialized = 'true';
+      refreshBtn.addEventListener('click', async () => {
+        refreshBtn.disabled = true;
+        const originalText = refreshBtn.textContent;
+        refreshBtn.textContent = 'Loading...';
+        await this.bridge.initPlaylistFetching(true, true);
+        refreshBtn.disabled = false;
+        refreshBtn.textContent = originalText;
+      });
+    }
+
+    const loadAllBtn = document.getElementById('loadAllPlaylistsBtn');
+    if (loadAllBtn && !loadAllBtn.dataset.initialized) {
+      loadAllBtn.dataset.initialized = 'true';
+      loadAllBtn.addEventListener('click', async () => {
+        loadAllBtn.disabled = true;
+        const originalText = loadAllBtn.textContent;
+        loadAllBtn.textContent = 'Loading...';
+        await this.bridge.initPlaylistFetching(true, false);
+        loadAllBtn.disabled = false;
+        loadAllBtn.textContent = originalText;
       });
     }
   }

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -8,6 +8,7 @@ import { UIHelper } from '../utils/ui-helper.js';
 import { BridgeUI } from './bridge-ui.js';
 import { TrackProcessor } from './track-processor.js';
 import { PlayerHandler } from './player-handler.js';
+import { CONSTANTS } from '../utils/constants.js';
 
 (function () {
   /**
@@ -171,11 +172,7 @@ import { PlayerHandler } from './player-handler.js';
    * Orchestrates the API, UI, and Track Processor
    */
   class Bridge {
-    // Constants
-    static TIMEOUT_DURATION = 100;
-    static PAGE_LOAD_TIMEOUT = 3000;
-    static BASE_URL = 'https://music.youtube.com/watch?v=';
-    static PLAYLIST_PAGE_PATH = 'https://music.youtube.com/playlist';
+    // Constants are now in CONSTANTS.API
 
     constructor() {
       this.ytMusicAPI = new YTMusicAPI();
@@ -333,14 +330,14 @@ import { PlayerHandler } from './player-handler.js';
       navigation?.addEventListener('navigate', (event) => {
         if (event.navigationType !== 'push') return;
 
-        const isPlaylistPage = event.destination?.url?.startsWith(Bridge.PLAYLIST_PAGE_PATH);
+        const isPlaylistPage = event.destination?.url?.startsWith(CONSTANTS.API.PLAYLIST_PAGE_PATH);
         if (isPlaylistPage) {
           setTimeout(() => {
             if (!this.extSettings || this.extSettings.showPlaylistButton !== false) {
               this.ui.injectActionButtons(this.extSettings);
               this.ui.showTriggerButtons(this.extSettings);
             }
-          }, Bridge.PAGE_LOAD_TIMEOUT);
+          }, CONSTANTS.API.PAGE_LOAD_TIMEOUT_MS);
         }
       });
 
@@ -440,7 +437,7 @@ import { PlayerHandler } from './player-handler.js';
 
       // Determine default value for onlyEditable if not provided
       if (onlyEditable === null) {
-        onlyEditable = this.extSettings?.loadAllPlaylists === true ? false : true;
+        onlyEditable = !this.extSettings?.loadAllPlaylists;
       }
 
       if (!forceRefresh && this.playlistsCache && this.playlistsCache.length > 0) {
@@ -462,7 +459,7 @@ import { PlayerHandler } from './player-handler.js';
         let playlists = await this.ytMusicAPI.getPlaylists(onlyEditable);
         
         if (playlists.length === 0) {
-          await this.sleep(1000);
+          await this.sleep(CONSTANTS.PLAYER.RETRY_INTERVAL_MS);
           playlists = await this.ytMusicAPI.getPlaylists(onlyEditable);
         }
         

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -435,8 +435,13 @@ import { PlayerHandler } from './player-handler.js';
     /**
      * Initializes playlist fetching and display
      */
-    async initPlaylistFetching(forceRefresh = false) {
+    async initPlaylistFetching(forceRefresh = false, onlyEditable = null) {
       if (this.isFetchingPlaylists) return;
+
+      // Determine default value for onlyEditable if not provided
+      if (onlyEditable === null) {
+        onlyEditable = this.extSettings?.loadAllPlaylists === true ? false : true;
+      }
 
       if (!forceRefresh && this.playlistsCache && this.playlistsCache.length > 0) {
         this.ui.displayPlaylistsForSelection(this.playlistsCache);
@@ -454,11 +459,11 @@ import { PlayerHandler } from './player-handler.js';
       if (playlistsGrid) playlistsGrid.replaceChildren();
 
       try {
-        let playlists = await this.ytMusicAPI.getEditablePlaylists();
+        let playlists = await this.ytMusicAPI.getPlaylists(onlyEditable);
         
         if (playlists.length === 0) {
           await this.sleep(1000);
-          playlists = await this.ytMusicAPI.getEditablePlaylists();
+          playlists = await this.ytMusicAPI.getPlaylists(onlyEditable);
         }
         
         this.playlistsCache = playlists;
@@ -510,6 +515,8 @@ import { PlayerHandler } from './player-handler.js';
      * Resets action buttons visibility for a newly selected playlist
      */
     resetActionButtonsForPlaylist() {
+      const isEditable = this.currentSelectedPlaylist?.isEditable !== false;
+
       document.getElementById('findLocalReplacementsBtn')?.classList.add('hidden');
       document.getElementById('findUnavailableBtn')?.classList.remove('hidden');
       document.getElementById('findVideoTracksBtn')?.classList.remove('hidden');
@@ -517,15 +524,21 @@ import { PlayerHandler } from './player-handler.js';
       document.getElementById('importFromFileBtn')?.classList.remove('hidden');
       document.getElementById('listAllTracksBtn')?.classList.remove('hidden');
       
-      document.getElementById('replaceSelectedBtn')?.classList.remove('hidden');
-      document.getElementById('removeSelectedBtn')?.classList.remove('hidden');
-      document.getElementById('addSelectedBtn')?.classList.remove('hidden');
+      const replaceBtn = document.getElementById('replaceSelectedBtn');
+      const removeBtn = document.getElementById('removeSelectedBtn');
+      const addBtn = document.getElementById('addSelectedBtn');
+
+      if (replaceBtn) replaceBtn.classList.toggle('hidden', !isEditable);
+      if (removeBtn) removeBtn.classList.toggle('hidden', !isEditable);
+      if (addBtn) addBtn.classList.toggle('hidden', !isEditable);
     }
 
     /**
      * Updates visibility of buttons for local import feature
      */
     updateImportButtonVisibility() {
+      const isEditable = this.currentSelectedPlaylist?.isEditable !== false;
+
       document.getElementById('findLocalReplacementsBtn')?.classList.remove('hidden');
       document.getElementById('findUnavailableBtn')?.classList.remove('hidden');
       document.getElementById('findVideoTracksBtn')?.classList.remove('hidden');
@@ -533,9 +546,13 @@ import { PlayerHandler } from './player-handler.js';
       document.getElementById('importFromFileBtn')?.classList.remove('hidden');
       document.getElementById('listAllTracksBtn')?.classList.remove('hidden');
       
-      document.getElementById('replaceSelectedBtn')?.classList.add('hidden');
-      document.getElementById('removeSelectedBtn')?.classList.add('hidden');
-      document.getElementById('addSelectedBtn')?.classList.remove('hidden');
+      const replaceBtn = document.getElementById('replaceSelectedBtn');
+      const removeBtn = document.getElementById('removeSelectedBtn');
+      const addBtn = document.getElementById('addSelectedBtn');
+
+      if (replaceBtn) replaceBtn.classList.add('hidden');
+      if (removeBtn) removeBtn.classList.add('hidden');
+      if (addBtn) addBtn.classList.toggle('hidden', !isEditable);
     }
 
     /**

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -2,6 +2,7 @@ import { DOMModifier } from '../utils/dom-modifier.js';
 import { MessageManager } from '../utils/messages.js';
 import { StorageManager } from '../utils/storage.js';
 import { PopupManager } from '../utils/popup-manager.js';
+import { CONSTANTS } from '../utils/constants.js';
 import bridgeUrl from './bridge.js?script&module';
 import popupHtmlUrl from '../html/in-site-popup.html?url';
 import popupCssUrl from '../styles/in-site-popup.css?url';
@@ -15,12 +16,7 @@ class ContentScriptController {
     this.domModifier = DOMModifier;
     this.messageManager = new MessageManager();
     this.storageManager = new StorageManager();
-    this.extSettings = { 
-      showNavButton: true, 
-      showPlaylistButton: true,
-      loadAllPlaylists: false,
-      hideWarningMessage: false
-    };
+    this.extSettings = { ...CONSTANTS.SETTINGS.DEFAULT };
     this.popupManager = null;
 
     this.setupListeners();
@@ -56,7 +52,7 @@ class ContentScriptController {
       this.extSettings = { ...this.extSettings, ...stored };
     } catch (error) {
       // Use default settings if load fails
-      this.extSettings = { showNavButton: true, showPlaylistButton: true, hideWarningMessage: false };
+      this.extSettings = { ...CONSTANTS.SETTINGS.DEFAULT };
     }
   }
 

--- a/scripts/content.js
+++ b/scripts/content.js
@@ -18,6 +18,7 @@ class ContentScriptController {
     this.extSettings = { 
       showNavButton: true, 
       showPlaylistButton: true,
+      loadAllPlaylists: false,
       hideWarningMessage: false
     };
     this.popupManager = null;
@@ -150,6 +151,19 @@ class ContentScriptController {
 
         case 'hidePopup':
           this.popupManager?.hidePopup();
+          sendResponse({ success: true });
+          break;
+
+        case 'settingsUpdated':
+          this.extSettings = { ...this.extSettings, ...message.settings };
+          if (this.popupManager) {
+            this.popupManager.extSettings = this.extSettings;
+          }
+          // Update bridge context
+          window.postMessage({ 
+            type: 'EXT_SETTINGS', 
+            settings: this.extSettings 
+          }, '*');
           sendResponse({ success: true });
           break;
 

--- a/scripts/models/playlist.js
+++ b/scripts/models/playlist.js
@@ -9,13 +9,15 @@ export class Playlist {
    * @param {string} [params.subtitle] - Subtitle (usually contains owner/track count)
    * @param {string} [params.owner] - The owner of the playlist
    * @param {string} [params.thumbnail] - URL to the playlist thumbnail
+   * @param {boolean} [params.isEditable] - Whether the playlist is editable by the user
    */
-  constructor({ id, title, subtitle = '', owner = '', thumbnail = '' }) {
+  constructor({ id, title, subtitle = '', owner = '', thumbnail = '', isEditable = false }) {
     this.id = id;
     this.title = title;
     this.subtitle = subtitle;
     this.owner = owner;
     this.thumbnail = thumbnail;
+    this.isEditable = isEditable;
   }
 
   /**

--- a/scripts/models/track.js
+++ b/scripts/models/track.js
@@ -1,12 +1,10 @@
 import { TextSimilarity } from '../../utils/utils.js';
+import { CONSTANTS } from '../../utils/constants.js';
 
 /**
  * Track - Represents a music track in YouTube Music
  */
 export class Track {
-  static GENERIC_NAME_REGEX = /^\d*\s*(?:-|_)?\s*(?:(?:unknown|untitled|misc)(?:\s*artist)?\s*(?:-|_)?\s*)?(?:track|audio\s*track|unknown|untitled|misc)\s*\d*$/i;
-  static VIDEO_SUFFIX_REGEX = /(official\s*)?(music\s*)?video/gi;
-
   /**
    * @param {Object} params
    * @param {string} params.name - Track name
@@ -79,7 +77,7 @@ export class Track {
    * @returns {string}
    */
   toSearchQuery() {
-    const cleanName = this.name.replace(Track.VIDEO_SUFFIX_REGEX, '').trim();
+    const cleanName = this.name.replace(CONSTANTS.REGEX.VIDEO_SUFFIX, '').trim();
     let query = cleanName;
     if (this.album) query += ` - ${this.album}`;
     if (this.artists && this.artists.length > 0) {
@@ -111,7 +109,7 @@ export class Track {
    * @param {number} threshold - Similarity threshold
    * @returns {boolean}
    */
-  updateMatchStatus(otherTitle, threshold = 0.5) {
+  updateMatchStatus(otherTitle, threshold = CONSTANTS.API.SIMILARITY_THRESHOLD) {
     this.matchScore = TextSimilarity.calculateJaroWinklerDistance(otherTitle, this.name);
     this.isGoodMatch = this.matchScore >= threshold;
     return this.isGoodMatch;

--- a/scripts/player-handler.js
+++ b/scripts/player-handler.js
@@ -1,3 +1,5 @@
+import { CONSTANTS } from '../utils/constants.js';
+
 /**
  * PlayerHandler - Handles playback controls within the YouTube Music UI
  * Provides play, pause, and seek functionality for each track
@@ -6,7 +8,7 @@ export class PlayerHandler {
   constructor() {
     this.initialized = false;
     this.retryCount = 0;
-    this.maxRetries = 10;
+    this.maxRetries = CONSTANTS.PLAYER.MAX_RETRIES;
   }
 
   /**
@@ -27,7 +29,7 @@ export class PlayerHandler {
     if (!this.api) {
       if (this.retryCount < this.maxRetries) {
         this.retryCount++;
-        setTimeout(() => this.init(), 1000);
+        setTimeout(() => this.init(), CONSTANTS.PLAYER.RETRY_INTERVAL_MS);
       } else {
         console.error('PlayerHandler: Failed to initialize after max retries.');
       }

--- a/scripts/re
+++ b/scripts/re
@@ -1,0 +1,1600 @@
+{
+    "responseContext": {
+        "serviceTrackingParams": [
+            {
+                "service": "GFEEDBACK",
+                "params": [
+                    {
+                        "key": "browse_id",
+                        "value": "FEmusic_liked_playlists"
+                    },
+                    {
+                        "key": "browse_id_prefix",
+                        "value": ""
+                    },
+                    {
+                        "key": "logged_in",
+                        "value": "1"
+                    }
+                ]
+            },
+            {
+                "service": "CSI",
+                "params": [
+                    {
+                        "key": "c",
+                        "value": "WEB_REMIX"
+                    },
+                    {
+                        "key": "cver",
+                        "value": "1.20260421.03.01"
+                    },
+                    {
+                        "key": "yt_li",
+                        "value": "1"
+                    },
+                    {
+                        "key": "GetBrowsePlaylistsPage_rid",
+                        "value": "0x9b352b99ce1655d2"
+                    }
+                ]
+            },
+            {
+                "service": "ECATCHER",
+                "params": [
+                    {
+                        "key": "client.version",
+                        "value": "1.20000101"
+                    },
+                    {
+                        "key": "client.name",
+                        "value": "WEB_REMIX"
+                    }
+                ]
+            }
+        ],
+        "responseId": "IhMIwvG7ypGLlAMV9MMQBh2cLSHJ"
+    },
+    "contents": {
+        "singleColumnBrowseResultsRenderer": {
+            "tabs": [
+                {
+                    "tabRenderer": {
+                        "endpoint": {
+                            "clickTrackingParams": "CAEQ8JMBGAQiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                            "commandExecutorCommand": {
+                                "commands": [
+                                    {
+                                        "clickTrackingParams": "CAEQ8JMBGAQiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                        "musicLibraryPersistLaunchNavigationCommand": {
+                                            "command": {
+                                                "clickTrackingParams": "CAEQ8JMBGAQiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                "browseEndpoint": {
+                                                    "browseId": "FEmusic_library_landing"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "clickTrackingParams": "CAEQ8JMBGAQiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                        "browseEndpoint": {
+                                            "browseId": "FEmusic_library_landing",
+                                            "browseEndpointContextSupportedConfigs": {
+                                                "browseEndpointContextMusicConfig": {
+                                                    "pageType": "MUSIC_PAGE_TYPE_LIBRARY_CONTENT_LANDING_PAGE"
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "title": "Library",
+                        "selected": true,
+                        "content": {
+                            "sectionListRenderer": {
+                                "contents": [
+                                    {
+                                        "gridRenderer": {
+                                            "items": [
+                                                {
+                                                    "musicTwoRowItemRenderer": {
+                                                        "thumbnailRenderer": {
+                                                            "musicThumbnailRenderer": {
+                                                                "thumbnail": {
+                                                                    "thumbnails": [
+                                                                        {
+                                                                            "url": "https://www.gstatic.com/youtube/media/ytm/images/pbg/create-playlist-@210.png",
+                                                                            "width": 210,
+                                                                            "height": 210
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FILL",
+                                                                "trackingParams": "CCoQhL8CIhMIwvG7ypGLlAMV9MMQBh2cLSHJ"
+                                                            }
+                                                        },
+                                                        "aspectRatio": "MUSIC_TWO_ROW_ITEM_THUMBNAIL_ASPECT_RATIO_SQUARE",
+                                                        "title": {
+                                                            "runs": [
+                                                                {
+                                                                    "text": "New playlist",
+                                                                    "navigationEndpoint": {
+                                                                        "clickTrackingParams": "CCUQoLMCGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                        "createPlaylistEndpoint": {
+                                                                            "params": "CAI%3D",
+                                                                            "createPlaylistDialog": {
+                                                                                "createPlaylistDialogRenderer": {
+                                                                                    "dialogTitle": {
+                                                                                        "runs": [
+                                                                                            {
+                                                                                                "text": "New playlist"
+                                                                                            }
+                                                                                        ]
+                                                                                    },
+                                                                                    "titlePlaceholder": "Title",
+                                                                                    "privacyOption": {
+                                                                                        "dropdownRenderer": {
+                                                                                            "entries": [
+                                                                                                {
+                                                                                                    "dropdownItemRenderer": {
+                                                                                                        "label": {
+                                                                                                            "runs": [
+                                                                                                                {
+                                                                                                                    "text": "Public"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "isSelected": true,
+                                                                                                        "accessibility": {
+                                                                                                            "label": "Public"
+                                                                                                        },
+                                                                                                        "int32Value": 1,
+                                                                                                        "icon": {
+                                                                                                            "iconType": "PRIVACY_PUBLIC"
+                                                                                                        },
+                                                                                                        "descriptionText": {
+                                                                                                            "runs": [
+                                                                                                                {
+                                                                                                                    "text": "YouTube channel required"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "dropdownItemRenderer": {
+                                                                                                        "label": {
+                                                                                                            "runs": [
+                                                                                                                {
+                                                                                                                    "text": "Unlisted"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "isSelected": false,
+                                                                                                        "accessibility": {
+                                                                                                            "label": "Unlisted"
+                                                                                                        },
+                                                                                                        "int32Value": 2,
+                                                                                                        "icon": {
+                                                                                                            "iconType": "LINK"
+                                                                                                        },
+                                                                                                        "descriptionText": {
+                                                                                                            "runs": [
+                                                                                                                {
+                                                                                                                    "text": "YouTube channel required"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    }
+                                                                                                },
+                                                                                                {
+                                                                                                    "dropdownItemRenderer": {
+                                                                                                        "label": {
+                                                                                                            "runs": [
+                                                                                                                {
+                                                                                                                    "text": "Private"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "isSelected": false,
+                                                                                                        "accessibility": {
+                                                                                                            "label": "Private"
+                                                                                                        },
+                                                                                                        "int32Value": 0,
+                                                                                                        "icon": {
+                                                                                                            "iconType": "LOCK"
+                                                                                                        },
+                                                                                                        "descriptionText": {
+                                                                                                            "runs": [
+                                                                                                                {
+                                                                                                                    "text": "Only you can view"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            ],
+                                                                                            "label": "Privacy",
+                                                                                            "accessibility": {
+                                                                                                "label": "Privacy"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "cancelButton": {
+                                                                                        "buttonRenderer": {
+                                                                                            "style": "STYLE_LIGHT_TEXT",
+                                                                                            "isDisabled": false,
+                                                                                            "text": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "Cancel"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "trackingParams": "CCkQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                                        }
+                                                                                    },
+                                                                                    "createButton": {
+                                                                                        "buttonRenderer": {
+                                                                                            "style": "STYLE_PRIMARY",
+                                                                                            "isDisabled": false,
+                                                                                            "text": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "Create"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "trackingParams": "CCgQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                                        }
+                                                                                    },
+                                                                                    "playlistCollaborateToggle": {
+                                                                                        "switchListItemViewModel": {
+                                                                                            "title": {
+                                                                                                "content": "Collaborate"
+                                                                                            },
+                                                                                            "isDisabled": false,
+                                                                                            "a11yLabelSwitchedOn": "On",
+                                                                                            "a11yLabelSwitchedOff": "Off"
+                                                                                        }
+                                                                                    },
+                                                                                    "createPlaylistParamsCollaborationEnabled": "KAE%3D",
+                                                                                    "createPlaylistParamsCollaborationDisabled": "KAA%3D",
+                                                                                    "errorMessages": [
+                                                                                        {
+                                                                                            "type": "CREATE_PLAYLIST_DIALOG_FIELD_ERROR_MESSAGE_TYPE_VISIBILITY_INVALID",
+                                                                                            "errorMessage": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "Change privacy to allow collaboration. "
+                                                                                                    },
+                                                                                                    {
+                                                                                                        "text": "Learn more",
+                                                                                                        "navigationEndpoint": {
+                                                                                                            "clickTrackingParams": "CCUQoLMCGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                                            "urlEndpoint": {
+                                                                                                                "url": "https://support.google.com/youtubemusic/answer/7205933?nohelpkit=1",
+                                                                                                                "target": "TARGET_NEW_WINDOW"
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "subtitle": {},
+                                                        "navigationEndpoint": {
+                                                            "clickTrackingParams": "CCUQoLMCGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                            "createPlaylistEndpoint": {
+                                                                "params": "CAI%3D",
+                                                                "createPlaylistDialog": {
+                                                                    "createPlaylistDialogRenderer": {
+                                                                        "dialogTitle": {
+                                                                            "runs": [
+                                                                                {
+                                                                                    "text": "New playlist"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "titlePlaceholder": "Title",
+                                                                        "privacyOption": {
+                                                                            "dropdownRenderer": {
+                                                                                "entries": [
+                                                                                    {
+                                                                                        "dropdownItemRenderer": {
+                                                                                            "label": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "Public"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "isSelected": true,
+                                                                                            "accessibility": {
+                                                                                                "label": "Public"
+                                                                                            },
+                                                                                            "int32Value": 1,
+                                                                                            "icon": {
+                                                                                                "iconType": "PRIVACY_PUBLIC"
+                                                                                            },
+                                                                                            "descriptionText": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "YouTube channel required"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "dropdownItemRenderer": {
+                                                                                            "label": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "Unlisted"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "isSelected": false,
+                                                                                            "accessibility": {
+                                                                                                "label": "Unlisted"
+                                                                                            },
+                                                                                            "int32Value": 2,
+                                                                                            "icon": {
+                                                                                                "iconType": "LINK"
+                                                                                            },
+                                                                                            "descriptionText": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "YouTube channel required"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "dropdownItemRenderer": {
+                                                                                            "label": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "Private"
+                                                                                                    }
+                                                                                                ]
+                                                                                            },
+                                                                                            "isSelected": false,
+                                                                                            "accessibility": {
+                                                                                                "label": "Private"
+                                                                                            },
+                                                                                            "int32Value": 0,
+                                                                                            "icon": {
+                                                                                                "iconType": "LOCK"
+                                                                                            },
+                                                                                            "descriptionText": {
+                                                                                                "runs": [
+                                                                                                    {
+                                                                                                        "text": "Only you can view"
+                                                                                                    }
+                                                                                                ]
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                ],
+                                                                                "label": "Privacy",
+                                                                                "accessibility": {
+                                                                                    "label": "Privacy"
+                                                                                }
+                                                                            }
+                                                                        },
+                                                                        "cancelButton": {
+                                                                            "buttonRenderer": {
+                                                                                "style": "STYLE_LIGHT_TEXT",
+                                                                                "isDisabled": false,
+                                                                                "text": {
+                                                                                    "runs": [
+                                                                                        {
+                                                                                            "text": "Cancel"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "trackingParams": "CCcQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                            }
+                                                                        },
+                                                                        "createButton": {
+                                                                            "buttonRenderer": {
+                                                                                "style": "STYLE_PRIMARY",
+                                                                                "isDisabled": false,
+                                                                                "text": {
+                                                                                    "runs": [
+                                                                                        {
+                                                                                            "text": "Create"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "trackingParams": "CCYQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                            }
+                                                                        },
+                                                                        "playlistCollaborateToggle": {
+                                                                            "switchListItemViewModel": {
+                                                                                "title": {
+                                                                                    "content": "Collaborate"
+                                                                                },
+                                                                                "isDisabled": false,
+                                                                                "a11yLabelSwitchedOn": "On",
+                                                                                "a11yLabelSwitchedOff": "Off"
+                                                                            }
+                                                                        },
+                                                                        "createPlaylistParamsCollaborationEnabled": "KAE%3D",
+                                                                        "createPlaylistParamsCollaborationDisabled": "KAA%3D",
+                                                                        "errorMessages": [
+                                                                            {
+                                                                                "type": "CREATE_PLAYLIST_DIALOG_FIELD_ERROR_MESSAGE_TYPE_VISIBILITY_INVALID",
+                                                                                "errorMessage": {
+                                                                                    "runs": [
+                                                                                        {
+                                                                                            "text": "Change privacy to allow collaboration. "
+                                                                                        },
+                                                                                        {
+                                                                                            "text": "Learn more",
+                                                                                            "navigationEndpoint": {
+                                                                                                "clickTrackingParams": "CCUQoLMCGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                                "urlEndpoint": {
+                                                                                                    "url": "https://support.google.com/youtubemusic/answer/7205933?nohelpkit=1",
+                                                                                                    "target": "TARGET_NEW_WINDOW"
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "trackingParams": "CCUQoLMCGAAiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                    }
+                                                },
+                                                {
+                                                    "musicTwoRowItemRenderer": {
+                                                        "thumbnailRenderer": {
+                                                            "musicThumbnailRenderer": {
+                                                                "thumbnail": {
+                                                                    "thumbnails": [
+                                                                        {
+                                                                            "url": "https://yt3.googleusercontent.com/p8elzPtCjF1JM2vBTPZIF4-FHdECCV0k0oR-KeFG6g5lu80NF7u8wdb7rIFna_D7gEPOCAXD2X4=s192",
+                                                                            "width": 192,
+                                                                            "height": 192
+                                                                        },
+                                                                        {
+                                                                            "url": "https://yt3.googleusercontent.com/p8elzPtCjF1JM2vBTPZIF4-FHdECCV0k0oR-KeFG6g5lu80NF7u8wdb7rIFna_D7gEPOCAXD2X4=s576",
+                                                                            "width": 576,
+                                                                            "height": 576
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FILL",
+                                                                "trackingParams": "CCQQhL8CIhMIwvG7ypGLlAMV9MMQBh2cLSHJ"
+                                                            }
+                                                        },
+                                                        "aspectRatio": "MUSIC_TWO_ROW_ITEM_THUMBNAIL_ASPECT_RATIO_SQUARE",
+                                                        "title": {
+                                                            "runs": [
+                                                                {
+                                                                    "text": "Malayalam Favourites",
+                                                                    "navigationEndpoint": {
+                                                                        "clickTrackingParams": "CBUQoLMCGAEiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                        "browseEndpoint": {
+                                                                            "browseId": "VLPLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX",
+                                                                            "browseEndpointContextSupportedConfigs": {
+                                                                                "browseEndpointContextMusicConfig": {
+                                                                                    "pageType": "MUSIC_PAGE_TYPE_PLAYLIST"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "subtitle": {
+                                                            "runs": [
+                                                                {
+                                                                    "text": "330 tracks"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "navigationEndpoint": {
+                                                            "clickTrackingParams": "CBUQoLMCGAEiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                            "browseEndpoint": {
+                                                                "browseId": "VLPLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX",
+                                                                "browseEndpointContextSupportedConfigs": {
+                                                                    "browseEndpointContextMusicConfig": {
+                                                                        "pageType": "MUSIC_PAGE_TYPE_PLAYLIST"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "trackingParams": "CBUQoLMCGAEiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                        "menu": {
+                                                            "menuRenderer": {
+                                                                "items": [
+                                                                    {
+                                                                        "menuNavigationItemRenderer": {
+                                                                            "text": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Shuffle play"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "icon": {
+                                                                                "iconType": "MUSIC_SHUFFLE"
+                                                                            },
+                                                                            "navigationEndpoint": {
+                                                                                "clickTrackingParams": "CCMQmvMFGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "watchPlaylistEndpoint": {
+                                                                                    "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX",
+                                                                                    "params": "wAEB8gECKAE%3D"
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CCMQmvMFGAAiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "menuNavigationItemRenderer": {
+                                                                            "text": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Start mix"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "icon": {
+                                                                                "iconType": "MIX"
+                                                                            },
+                                                                            "navigationEndpoint": {
+                                                                                "clickTrackingParams": "CCIQm_MFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "watchPlaylistEndpoint": {
+                                                                                    "playlistId": "RDAMPLPLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX",
+                                                                                    "params": "wAEB"
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CCIQm_MFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "menuServiceItemRenderer": {
+                                                                            "text": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Play next"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "icon": {
+                                                                                "iconType": "QUEUE_PLAY_NEXT"
+                                                                            },
+                                                                            "serviceEndpoint": {
+                                                                                "clickTrackingParams": "CCAQvu4FGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "queueAddEndpoint": {
+                                                                                    "queueTarget": {
+                                                                                        "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX",
+                                                                                        "onEmptyQueue": {
+                                                                                            "clickTrackingParams": "CCAQvu4FGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                            "watchEndpoint": {
+                                                                                                "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                                                                    "commands": [
+                                                                                        {
+                                                                                            "clickTrackingParams": "CCAQvu4FGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                            "addToToastAction": {
+                                                                                                "item": {
+                                                                                                    "notificationTextRenderer": {
+                                                                                                        "successResponseText": {
+                                                                                                            "runs": [
+                                                                                                                {
+                                                                                                                    "text": "Playlist will play next"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "trackingParams": "CCEQyscDIhMIwvG7ypGLlAMV9MMQBh2cLSHJ"
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CCAQvu4FGAIiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "menuServiceItemRenderer": {
+                                                                            "text": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Add to queue"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "icon": {
+                                                                                "iconType": "ADD_TO_REMOTE_QUEUE"
+                                                                            },
+                                                                            "serviceEndpoint": {
+                                                                                "clickTrackingParams": "CB4Q--8FGAMiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "queueAddEndpoint": {
+                                                                                    "queueTarget": {
+                                                                                        "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX",
+                                                                                        "onEmptyQueue": {
+                                                                                            "clickTrackingParams": "CB4Q--8FGAMiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                            "watchEndpoint": {
+                                                                                                "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "queueInsertPosition": "INSERT_AT_END",
+                                                                                    "commands": [
+                                                                                        {
+                                                                                            "clickTrackingParams": "CB4Q--8FGAMiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                            "addToToastAction": {
+                                                                                                "item": {
+                                                                                                    "notificationTextRenderer": {
+                                                                                                        "successResponseText": {
+                                                                                                            "runs": [
+                                                                                                                {
+                                                                                                                    "text": "Playlist added to queue"
+                                                                                                                }
+                                                                                                            ]
+                                                                                                        },
+                                                                                                        "trackingParams": "CB8QyscDIhMIwvG7ypGLlAMV9MMQBh2cLSHJ"
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CB4Q--8FGAMiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "toggleMenuServiceItemRenderer": {
+                                                                            "defaultText": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Save playlist to library"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "defaultIcon": {
+                                                                                "iconType": "BOOKMARK_BORDER"
+                                                                            },
+                                                                            "defaultServiceEndpoint": {
+                                                                                "clickTrackingParams": "CB0QhP8FGAQiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "likeEndpoint": {
+                                                                                    "status": "LIKE",
+                                                                                    "target": {
+                                                                                        "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX"
+                                                                                    }
+                                                                                }
+                                                                            },
+                                                                            "toggledText": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Remove playlist from library"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "toggledIcon": {
+                                                                                "iconType": "BOOKMARK"
+                                                                            },
+                                                                            "toggledServiceEndpoint": {
+                                                                                "clickTrackingParams": "CB0QhP8FGAQiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "likeEndpoint": {
+                                                                                    "status": "INDIFFERENT",
+                                                                                    "target": {
+                                                                                        "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX"
+                                                                                    },
+                                                                                    "actions": [
+                                                                                        {
+                                                                                            "clickTrackingParams": "CB0QhP8FGAQiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                            "hideEnclosingAction": {
+                                                                                                "hack": true
+                                                                                            }
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CB0QhP8FGAQiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "menuNavigationItemRenderer": {
+                                                                            "text": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Save to playlist"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "icon": {
+                                                                                "iconType": "ADD_TO_PLAYLIST"
+                                                                            },
+                                                                            "navigationEndpoint": {
+                                                                                "clickTrackingParams": "CBwQw5QGGAUiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "addToPlaylistEndpoint": {
+                                                                                    "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX"
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CBwQw5QGGAUiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "menuNavigationItemRenderer": {
+                                                                            "text": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Share"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "icon": {
+                                                                                "iconType": "SHARE"
+                                                                            },
+                                                                            "navigationEndpoint": {
+                                                                                "clickTrackingParams": "CBkQkfsFGAYiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "showDialogCommand": {
+                                                                                    "panelLoadingStrategy": {
+                                                                                        "inlineContent": {
+                                                                                            "dialogViewModel": {
+                                                                                                "header": {
+                                                                                                    "dialogHeaderViewModel": {
+                                                                                                        "headline": {
+                                                                                                            "content": "Make your playlist shareable"
+                                                                                                        }
+                                                                                                    }
+                                                                                                },
+                                                                                                "footer": {
+                                                                                                    "panelFooterViewModel": {
+                                                                                                        "primaryButton": {
+                                                                                                            "buttonViewModel": {
+                                                                                                                "title": "Confirm",
+                                                                                                                "onTap": {
+                                                                                                                    "innertubeCommand": {
+                                                                                                                        "clickTrackingParams": "CBsQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                                                        "commandExecutorCommand": {
+                                                                                                                            "commands": [
+                                                                                                                                {
+                                                                                                                                    "clickTrackingParams": "CBsQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                                                                    "dismissDialogEndpoint": {}
+                                                                                                                                },
+                                                                                                                                {
+                                                                                                                                    "clickTrackingParams": "CBsQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                                                                    "webSubmitFormCommand": {
+                                                                                                                                        "formId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX"
+                                                                                                                                    }
+                                                                                                                                }
+                                                                                                                            ]
+                                                                                                                        }
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "accessibilityText": "Confirm",
+                                                                                                                "style": "BUTTON_VIEW_MODEL_STYLE_MONO",
+                                                                                                                "trackingParams": "CBsQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                                                                                "isFullWidth": false,
+                                                                                                                "type": "BUTTON_VIEW_MODEL_TYPE_FILLED",
+                                                                                                                "buttonSize": "BUTTON_VIEW_MODEL_SIZE_DEFAULT",
+                                                                                                                "state": "BUTTON_VIEW_MODEL_STATE_DISABLED"
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "secondaryButton": {
+                                                                                                            "buttonViewModel": {
+                                                                                                                "title": "Cancel",
+                                                                                                                "onTap": {
+                                                                                                                    "innertubeCommand": {
+                                                                                                                        "clickTrackingParams": "CBoQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                                                        "dismissDialogEndpoint": {}
+                                                                                                                    }
+                                                                                                                },
+                                                                                                                "accessibilityText": "Cancel",
+                                                                                                                "style": "BUTTON_VIEW_MODEL_STYLE_MONO",
+                                                                                                                "trackingParams": "CBoQ8FsiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                                                                                "isFullWidth": false,
+                                                                                                                "type": "BUTTON_VIEW_MODEL_TYPE_OUTLINE",
+                                                                                                                "buttonSize": "BUTTON_VIEW_MODEL_SIZE_DEFAULT"
+                                                                                                            }
+                                                                                                        },
+                                                                                                        "shouldHideDivider": true
+                                                                                                    }
+                                                                                                },
+                                                                                                "content": {
+                                                                                                    "radioButtonGroupViewModel": {
+                                                                                                        "key": "6a446b18-0000-2d9c-8a46-04006e752810",
+                                                                                                        "radioButtons": [
+                                                                                                            {
+                                                                                                                "radioButtonItemViewModel": {
+                                                                                                                    "key": "public",
+                                                                                                                    "text": "Public",
+                                                                                                                    "subtext": "Anyone can search for and view. Channel creation required.",
+                                                                                                                    "command": {
+                                                                                                                        "innertubeCommand": {
+                                                                                                                            "clickTrackingParams": "CBkQkfsFGAYiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                                                            "channelCreationFormEndpoint": {
+                                                                                                                                "channelCreationToken": "R2tEcWxMYm5BVG9LSWxCTVVVazNlRkZQTWpaVGFETnZkSFJQTWsxVlpEaG5XVXMxTFdwUGRFbDJaMWdTQkRBSmFBRWFEa1ZCUlRSQlYyOURRMEZGSlRORQ==",
+                                                                                                                                "source": "EDIT_PLAYLIST_PRIVACY_DROPDOWN_CHANNEL_CREATION_SOURCE"
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    "customHorizontalPadding": 0
+                                                                                                                }
+                                                                                                            },
+                                                                                                            {
+                                                                                                                "radioButtonItemViewModel": {
+                                                                                                                    "key": "unlisted",
+                                                                                                                    "text": "Unlisted",
+                                                                                                                    "subtext": "Anyone with the link can view. Channel creation required.",
+                                                                                                                    "command": {
+                                                                                                                        "innertubeCommand": {
+                                                                                                                            "clickTrackingParams": "CBkQkfsFGAYiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                                                            "channelCreationFormEndpoint": {
+                                                                                                                                "channelCreationToken": "R2tEcWxMYm5BVG9LSWxCTVVVazNlRkZQTWpaVGFETnZkSFJQTWsxVlpEaG5XVXMxTFdwUGRFbDJaMWdTQkRBSmFBSWFEa1ZCUlRSQlYyOURRMEZGSlRORQ==",
+                                                                                                                                "source": "EDIT_PLAYLIST_PRIVACY_DROPDOWN_CHANNEL_CREATION_SOURCE"
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    },
+                                                                                                                    "customHorizontalPadding": 0
+                                                                                                                }
+                                                                                                            }
+                                                                                                        ]
+                                                                                                    }
+                                                                                                },
+                                                                                                "formId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX"
+                                                                                            }
+                                                                                        }
+                                                                                    },
+                                                                                    "removeDefaultPadding": true
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CBkQkfsFGAYiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    },
+                                                                    {
+                                                                        "toggleMenuServiceItemRenderer": {
+                                                                            "defaultText": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Pin to Listen again"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "defaultIcon": {
+                                                                                "iconType": "KEEP"
+                                                                            },
+                                                                            "defaultServiceEndpoint": {
+                                                                                "clickTrackingParams": "CBgQ_t4KGAciEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "feedbackEndpoint": {
+                                                                                    "feedbackToken": "AB9zfpKn84koFCw0nIvj8prbiViq7WAhiusK8xtOd7IgAqNjC8evvZ1nSvLrn-npxhkQy9iktxqpK74t8sy1cPUrEkdWRfMDe4Jr81BolhUq0EEVCYmknZAbAHtYDzEiCKOH97HncSbS"
+                                                                                }
+                                                                            },
+                                                                            "toggledText": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Unpin from Listen again"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "toggledIcon": {
+                                                                                "iconType": "KEEP_OFF"
+                                                                            },
+                                                                            "toggledServiceEndpoint": {
+                                                                                "clickTrackingParams": "CBgQ_t4KGAciEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "feedbackEndpoint": {
+                                                                                    "feedbackToken": "AB9zfpLbHpEHcznkZ6Uf3Vh0is_uLtzyU-gMVRf_I5GEbNMkrs2VrhQBDEjrNIEDUvHirqrQ2E3pGw6L3rEBiyUFxxBfGkyJLMe5qvgSYO8uQoRZkAVX5N5EwyDNOi36TcFz4PIhuCOE"
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CBgQ_t4KGAciEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    }
+                                                                ],
+                                                                "trackingParams": "CBcQpzsiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                                "accessibility": {
+                                                                    "accessibilityData": {
+                                                                        "label": "Action menu"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "thumbnailOverlay": {
+                                                            "musicItemThumbnailOverlayRenderer": {
+                                                                "background": {
+                                                                    "verticalGradient": {
+                                                                        "gradientLayerColors": [
+                                                                            "2147483648",
+                                                                            "0",
+                                                                            "0"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "content": {
+                                                                    "musicPlayButtonRenderer": {
+                                                                        "playNavigationEndpoint": {
+                                                                            "clickTrackingParams": "CBYQyN4CIhMIwvG7ypGLlAMV9MMQBh2cLSHJygEEfhFz_w==",
+                                                                            "watchPlaylistEndpoint": {
+                                                                                "playlistId": "PLQI7xQO26Sh3ottO2MUd8gYK5-jOtIvgX",
+                                                                                "params": "wAEB"
+                                                                            }
+                                                                        },
+                                                                        "trackingParams": "CBYQyN4CIhMIwvG7ypGLlAMV9MMQBh2cLSHJ",
+                                                                        "playIcon": {
+                                                                            "iconType": "PLAY_ARROW"
+                                                                        },
+                                                                        "pauseIcon": {
+                                                                            "iconType": "PAUSE"
+                                                                        },
+                                                                        "iconColor": 4294967295,
+                                                                        "backgroundColor": 2566914048,
+                                                                        "activeBackgroundColor": 4278190080,
+                                                                        "loadingIndicatorColor": 14745645,
+                                                                        "playingIcon": {
+                                                                            "iconType": "VOLUME_UP"
+                                                                        },
+                                                                        "iconLoadingColor": 1308622847,
+                                                                        "activeScaleFactor": 1.2,
+                                                                        "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_MEDIUM",
+                                                                        "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                                                        "accessibilityPlayData": {
+                                                                            "accessibilityData": {
+                                                                                "label": "Play Malayalam Favourites"
+                                                                            }
+                                                                        },
+                                                                        "accessibilityPauseData": {
+                                                                            "accessibilityData": {
+                                                                                "label": "Pause Malayalam Favourites"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_BOTTOM_RIGHT",
+                                                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_HOVER"
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "musicTwoRowItemRenderer": {
+                                                        "thumbnailRenderer": {
+                                                            "musicThumbnailRenderer": {
+                                                                "thumbnail": {
+                                                                    "thumbnails": [
+                                                                        {
+                                                                            "url": "https://www.gstatic.com/youtube/media/ytm/images/pbg/podcast-queue-delhi-192.png",
+                                                                            "width": 192,
+                                                                            "height": 192
+                                                                        },
+                                                                        {
+                                                                            "url": "https://www.gstatic.com/youtube/media/ytm/images/pbg/podcast-queue-delhi-576.png",
+                                                                            "width": 576,
+                                                                            "height": 576
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FILL",
+                                                                "trackingParams": "CBQQhL8CIhMIwvG7ypGLlAMV9MMQBh2cLSHJ"
+                                                            }
+                                                        },
+                                                        "aspectRatio": "MUSIC_TWO_ROW_ITEM_THUMBNAIL_ASPECT_RATIO_SQUARE",
+                                                        "title": {
+                                                            "runs": [
+                                                                {
+                                                                    "text": "Episodes for Later",
+                                                                    "navigationEndpoint": {
+                                                                        "clickTrackingParams": "CBAQoLMCGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                        "browseEndpoint": {
+                                                                            "browseId": "VLSE",
+                                                                            "browseEndpointContextSupportedConfigs": {
+                                                                                "browseEndpointContextMusicConfig": {
+                                                                                    "pageType": "MUSIC_PAGE_TYPE_PLAYLIST"
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        "subtitle": {
+                                                            "runs": [
+                                                                {
+                                                                    "text": "Your queued episodes"
+                                                                }
+                                                            ]
+                                                        },
+                                                        "navigationEndpoint": {
+                                                            "clickTrackingParams": "CBAQoLMCGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                            "browseEndpoint": {
+                                                                "browseId": "VLSE",
+                                                                "browseEndpointContextSupportedConfigs": {
+                                                                    "browseEndpointContextMusicConfig": {
+                                                                        "pageType": "MUSIC_PAGE_TYPE_PLAYLIST"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "trackingParams": "CBAQoLMCGAIiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                        "menu": {
+                                                            "menuRenderer": {
+                                                                "items": [
+                                                                    {
+                                                                        "toggleMenuServiceItemRenderer": {
+                                                                            "defaultText": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Pin to Listen again"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "defaultIcon": {
+                                                                                "iconType": "KEEP"
+                                                                            },
+                                                                            "defaultServiceEndpoint": {
+                                                                                "clickTrackingParams": "CBMQ_t4KGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "feedbackEndpoint": {
+                                                                                    "feedbackToken": "AB9zfpJKX6NtLY4_Z8Cf16lkdmLnOciYuWb4IeHDsR3yimbSPxPcQrGCFYryilvN9_i2ixG09Why6ieA70S9VCvKCjI3Yyb8tg"
+                                                                                }
+                                                                            },
+                                                                            "toggledText": {
+                                                                                "runs": [
+                                                                                    {
+                                                                                        "text": "Unpin from Listen again"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            "toggledIcon": {
+                                                                                "iconType": "KEEP_OFF"
+                                                                            },
+                                                                            "toggledServiceEndpoint": {
+                                                                                "clickTrackingParams": "CBMQ_t4KGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                "feedbackEndpoint": {
+                                                                                    "feedbackToken": "AB9zfpLmVKkAO9Tn6w7903HLwS0ACxaUpbfjMfl18QMCcuxxdUUcKupQM9h9dC0PfITOaP9BIOUVAYWAGqntZiA0mW-jmF-U0g"
+                                                                                }
+                                                                            },
+                                                                            "trackingParams": "CBMQ_t4KGAAiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                                        }
+                                                                    }
+                                                                ],
+                                                                "trackingParams": "CBIQpzsiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                                "accessibility": {
+                                                                    "accessibilityData": {
+                                                                        "label": "Action menu"
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "thumbnailOverlay": {
+                                                            "musicItemThumbnailOverlayRenderer": {
+                                                                "background": {
+                                                                    "verticalGradient": {
+                                                                        "gradientLayerColors": [
+                                                                            "2147483648",
+                                                                            "0",
+                                                                            "0"
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "content": {
+                                                                    "musicPlayButtonRenderer": {
+                                                                        "playNavigationEndpoint": {
+                                                                            "clickTrackingParams": "CBEQyN4CIhMIwvG7ypGLlAMV9MMQBh2cLSHJygEEfhFz_w==",
+                                                                            "watchPlaylistEndpoint": {
+                                                                                "playlistId": "SE",
+                                                                                "params": "wAEB"
+                                                                            }
+                                                                        },
+                                                                        "trackingParams": "CBEQyN4CIhMIwvG7ypGLlAMV9MMQBh2cLSHJ",
+                                                                        "playIcon": {
+                                                                            "iconType": "PLAY_ARROW"
+                                                                        },
+                                                                        "pauseIcon": {
+                                                                            "iconType": "PAUSE"
+                                                                        },
+                                                                        "iconColor": 4294967295,
+                                                                        "backgroundColor": 2566914048,
+                                                                        "activeBackgroundColor": 4278190080,
+                                                                        "loadingIndicatorColor": 14745645,
+                                                                        "playingIcon": {
+                                                                            "iconType": "VOLUME_UP"
+                                                                        },
+                                                                        "iconLoadingColor": 1308622847,
+                                                                        "activeScaleFactor": 1.2,
+                                                                        "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_MEDIUM",
+                                                                        "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                                                        "accessibilityPlayData": {
+                                                                            "accessibilityData": {
+                                                                                "label": "Play Episodes for Later"
+                                                                            }
+                                                                        },
+                                                                        "accessibilityPauseData": {
+                                                                            "accessibilityData": {
+                                                                                "label": "Pause Episodes for Later"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_BOTTOM_RIGHT",
+                                                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_HOVER"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "trackingParams": "CA8Q6IsCGAAiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                            "itemSize": "COLLECTION_STYLE_ITEM_SIZE_SMALL"
+                                        }
+                                    }
+                                ],
+                                "trackingParams": "CAIQui8iEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                "header": {
+                                    "musicSideAlignedItemRenderer": {
+                                        "startItems": [
+                                            {
+                                                "chipCloudRenderer": {
+                                                    "chips": [
+                                                        {
+                                                            "chipCloudChipRenderer": {
+                                                                "navigationEndpoint": {
+                                                                    "clickTrackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                    "commandExecutorCommand": {
+                                                                        "commands": [
+                                                                            {
+                                                                                "clickTrackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                "browseEndpoint": {
+                                                                                    "browseId": "FEmusic_library_landing"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "clickTrackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                "musicLibraryPersistLaunchNavigationCommand": {
+                                                                                    "command": {
+                                                                                        "clickTrackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                        "browseEndpoint": {
+                                                                                            "browseId": "FEmusic_library_landing"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "trackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hyQ==",
+                                                                "icon": {
+                                                                    "iconType": "CLOSE"
+                                                                },
+                                                                "accessibilityData": {
+                                                                    "accessibilityData": {
+                                                                        "label": "Clear filters"
+                                                                    }
+                                                                },
+                                                                "isSelected": true,
+                                                                "onDeselectedCommand": {
+                                                                    "clickTrackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                    "commandExecutorCommand": {
+                                                                        "commands": [
+                                                                            {
+                                                                                "clickTrackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                "browseEndpoint": {
+                                                                                    "browseId": "FEmusic_library_landing"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "clickTrackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                "musicLibraryPersistLaunchNavigationCommand": {
+                                                                                    "command": {
+                                                                                        "clickTrackingParams": "CA4Q_V0YACITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                        "browseEndpoint": {
+                                                                                            "browseId": "FEmusic_library_landing"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        {
+                                                            "chipCloudChipRenderer": {
+                                                                "text": {
+                                                                    "runs": [
+                                                                        {
+                                                                            "text": "Playlists"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "navigationEndpoint": {
+                                                                    "clickTrackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                    "commandExecutorCommand": {
+                                                                        "commands": [
+                                                                            {
+                                                                                "clickTrackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                "browseEndpoint": {
+                                                                                    "browseId": "FEmusic_liked_playlists"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "clickTrackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                "musicLibraryPersistLaunchNavigationCommand": {
+                                                                                    "command": {
+                                                                                        "clickTrackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                        "browseEndpoint": {
+                                                                                            "browseId": "FEmusic_liked_playlists"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "trackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hyQ==",
+                                                                "accessibilityData": {
+                                                                    "accessibilityData": {
+                                                                        "label": "Show playlists"
+                                                                    }
+                                                                },
+                                                                "isSelected": true,
+                                                                "onDeselectedCommand": {
+                                                                    "clickTrackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                    "commandExecutorCommand": {
+                                                                        "commands": [
+                                                                            {
+                                                                                "clickTrackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                "browseEndpoint": {
+                                                                                    "browseId": "FEmusic_library_landing"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "clickTrackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                "musicLibraryPersistLaunchNavigationCommand": {
+                                                                                    "command": {
+                                                                                        "clickTrackingParams": "CA0Q_V0YASITCMLxu8qRi5QDFfTDEAYdnC0hycoBBH4Rc_8=",
+                                                                                        "browseEndpoint": {
+                                                                                            "browseId": "FEmusic_library_landing"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                "uniqueId": "Playlists"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "trackingParams": "CAwQ_F0YACITCMLxu8qRi5QDFfTDEAYdnC0hyQ=="
+                                                }
+                                            }
+                                        ],
+                                        "endItems": [
+                                            {
+                                                "musicSortFilterButtonRenderer": {
+                                                    "title": {
+                                                        "runs": [
+                                                            {
+                                                                "text": "Recently saved"
+                                                            }
+                                                        ]
+                                                    },
+                                                    "icon": {
+                                                        "iconType": "CHEVRON_DOWN"
+                                                    },
+                                                    "menu": {
+                                                        "musicMultiSelectMenuRenderer": {
+                                                            "title": {
+                                                                "musicMenuTitleRenderer": {
+                                                                    "primaryText": {
+                                                                        "runs": [
+                                                                            {
+                                                                                "text": "Sort by"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            },
+                                                            "options": [
+                                                                {
+                                                                    "musicMultiSelectMenuItemRenderer": {
+                                                                        "title": {
+                                                                            "runs": [
+                                                                                {
+                                                                                    "text": "Recently saved"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "formItemEntityKey": "EndQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9BRERFRF9USU1FU1RBTVBfU29ydFNwZWNfT3JkZXJfREVTQ0VORElORyCRASgB",
+                                                                        "selectedCommand": {
+                                                                            "clickTrackingParams": "CAoQk5QFGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                            "commandExecutorCommand": {
+                                                                                "commands": [
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAoQk5QFGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EnNQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9ERVNDRU5ESU5HIJEBKAE%3D",
+                                                                                            "newCheckedState": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAoQk5QFGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EnJQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9BU0NFTkRJTkcgkQEoAQ%3D%3D",
+                                                                                            "newCheckedState": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAoQk5QFGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EndQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9BRERFRF9USU1FU1RBTVBfU29ydFNwZWNfT3JkZXJfREVTQ0VORElORyCRASgB",
+                                                                                            "newCheckedState": true
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAoQk5QFGAAiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "browseSectionListReloadEndpoint": {
+                                                                                            "continuation": {
+                                                                                                "reloadContinuationData": {
+                                                                                                    "continuation": "4qmFsgIrEhdGRW11c2ljX2xpa2VkX3BsYXlsaXN0cxoQZ2dNR0tnUUlBQkFCb0FZQg%3D%3D",
+                                                                                                    "clickTrackingParams": "CAsQxqYCIhMIwvG7ypGLlAMV9MMQBh2cLSHJygEEfhFz_w==",
+                                                                                                    "showSpinnerOverlay": true
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "trackingParams": "CAoQk5QFGAAiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                                        "selectedIcon": {
+                                                                            "iconType": "CHECK"
+                                                                        },
+                                                                        "selectedAccessibility": {
+                                                                            "accessibilityData": {
+                                                                                "label": "Recently saved selected"
+                                                                            }
+                                                                        },
+                                                                        "deselectedAccessibility": {
+                                                                            "accessibilityData": {
+                                                                                "label": "Recently saved"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "musicMultiSelectMenuItemRenderer": {
+                                                                        "title": {
+                                                                            "runs": [
+                                                                                {
+                                                                                    "text": "A to Z"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "formItemEntityKey": "EnJQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9BU0NFTkRJTkcgkQEoAQ%3D%3D",
+                                                                        "selectedCommand": {
+                                                                            "clickTrackingParams": "CAgQk5QFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                            "commandExecutorCommand": {
+                                                                                "commands": [
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAgQk5QFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EnJQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9BU0NFTkRJTkcgkQEoAQ%3D%3D",
+                                                                                            "newCheckedState": true
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAgQk5QFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EnNQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9ERVNDRU5ESU5HIJEBKAE%3D",
+                                                                                            "newCheckedState": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAgQk5QFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EndQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9BRERFRF9USU1FU1RBTVBfU29ydFNwZWNfT3JkZXJfREVTQ0VORElORyCRASgB",
+                                                                                            "newCheckedState": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAgQk5QFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "browseSectionListReloadEndpoint": {
+                                                                                            "continuation": {
+                                                                                                "reloadContinuationData": {
+                                                                                                    "continuation": "4qmFsgIrEhdGRW11c2ljX2xpa2VkX3BsYXlsaXN0cxoQZ2dNR0tnUUlBUkFBb0FZQg%3D%3D",
+                                                                                                    "clickTrackingParams": "CAkQxqYCIhMIwvG7ypGLlAMV9MMQBh2cLSHJygEEfhFz_w==",
+                                                                                                    "showSpinnerOverlay": true
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "trackingParams": "CAgQk5QFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                                        "selectedIcon": {
+                                                                            "iconType": "CHECK"
+                                                                        },
+                                                                        "selectedAccessibility": {
+                                                                            "accessibilityData": {
+                                                                                "label": "A to Z selected"
+                                                                            }
+                                                                        },
+                                                                        "deselectedAccessibility": {
+                                                                            "accessibilityData": {
+                                                                                "label": "A to Z"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "musicMultiSelectMenuItemRenderer": {
+                                                                        "title": {
+                                                                            "runs": [
+                                                                                {
+                                                                                    "text": "Z to A"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        "formItemEntityKey": "EnNQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9ERVNDRU5ESU5HIJEBKAE%3D",
+                                                                        "selectedCommand": {
+                                                                            "clickTrackingParams": "CAYQk5QFGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                            "commandExecutorCommand": {
+                                                                                "commands": [
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAYQk5QFGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EnJQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9BU0NFTkRJTkcgkQEoAQ%3D%3D",
+                                                                                            "newCheckedState": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAYQk5QFGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EnNQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9ERVNDRU5ESU5HIJEBKAE%3D",
+                                                                                            "newCheckedState": true
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAYQk5QFGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "musicCheckboxFormItemMutatedCommand": {
+                                                                                            "formItemEntityKey": "EndQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9BRERFRF9USU1FU1RBTVBfU29ydFNwZWNfT3JkZXJfREVTQ0VORElORyCRASgB",
+                                                                                            "newCheckedState": false
+                                                                                        }
+                                                                                    },
+                                                                                    {
+                                                                                        "clickTrackingParams": "CAYQk5QFGAIiEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+                                                                                        "browseSectionListReloadEndpoint": {
+                                                                                            "continuation": {
+                                                                                                "reloadContinuationData": {
+                                                                                                    "continuation": "4qmFsgIrEhdGRW11c2ljX2xpa2VkX3BsYXlsaXN0cxoQZ2dNR0tnUUlBUkFCb0FZQg%3D%3D",
+                                                                                                    "clickTrackingParams": "CAcQxqYCIhMIwvG7ypGLlAMV9MMQBh2cLSHJygEEfhFz_w==",
+                                                                                                    "showSpinnerOverlay": true
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "trackingParams": "CAYQk5QFGAIiEwjC8bvKkYuUAxX0wxAGHZwtIck=",
+                                                                        "selectedIcon": {
+                                                                            "iconType": "CHECK"
+                                                                        },
+                                                                        "selectedAccessibility": {
+                                                                            "accessibilityData": {
+                                                                                "label": "Z to A selected"
+                                                                            }
+                                                                        },
+                                                                        "deselectedAccessibility": {
+                                                                            "accessibilityData": {
+                                                                                "label": "Z to A"
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "trackingParams": "CAUQkpQFIhMIwvG7ypGLlAMV9MMQBh2cLSHJ",
+                                                            "formEntityKey": "Ej9QQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UgkAEoAQ%3D%3D"
+                                                        }
+                                                    },
+                                                    "accessibility": {
+                                                        "accessibilityData": {
+                                                            "label": "Sort by - Recently saved selected, dropdown"
+                                                        }
+                                                    },
+                                                    "trackingParams": "CAQQkZQFGAEiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                                                }
+                                            }
+                                        ],
+                                        "trackingParams": "CAMQxv4DIhMIwvG7ypGLlAMV9MMQBh2cLSHJ"
+                                    }
+                                }
+                            }
+                        },
+                        "tabIdentifier": "FEmusic_library_landing",
+                        "trackingParams": "CAEQ8JMBGAQiEwjC8bvKkYuUAxX0wxAGHZwtIck="
+                    }
+                }
+            ]
+        }
+    },
+    "trackingParams": "CAAQhGciEwjC8bvKkYuUAxX0wxAGHZwtIcnKAQR-EXP_",
+    "frameworkUpdates": {
+        "entityBatchUpdate": {
+            "mutations": [
+                {
+                    "entityKey": "Ej9QQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UgkAEoAQ%3D%3D",
+                    "type": "ENTITY_MUTATION_TYPE_REPLACE",
+                    "payload": {
+                        "musicForm": {
+                            "id": "Ej9QQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UgkAEoAQ%3D%3D",
+                            "booleanChoiceEntityKeys": [
+                                "EndQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9BRERFRF9USU1FU1RBTVBfU29ydFNwZWNfT3JkZXJfREVTQ0VORElORyCRASgB",
+                                "EnNQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9ERVNDRU5ESU5HIJEBKAE%3D",
+                                "EnJQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9BU0NFTkRJTkcgkQEoAQ%3D%3D"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "entityKey": "EndQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9BRERFRF9USU1FU1RBTVBfU29ydFNwZWNfT3JkZXJfREVTQ0VORElORyCRASgB",
+                    "type": "ENTITY_MUTATION_TYPE_REPLACE",
+                    "payload": {
+                        "musicFormBooleanChoice": {
+                            "id": "EndQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9BRERFRF9USU1FU1RBTVBfU29ydFNwZWNfT3JkZXJfREVTQ0VORElORyCRASgB",
+                            "parentFormEntityKey": "Ej9QQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UgkAEoAQ%3D%3D",
+                            "selected": true,
+                            "opaqueToken": "SortSpec_Type_ADDED_TIMESTAMP_SortSpec_Order_DESCENDING"
+                        }
+                    }
+                },
+                {
+                    "entityKey": "EnJQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9BU0NFTkRJTkcgkQEoAQ%3D%3D",
+                    "type": "ENTITY_MUTATION_TYPE_REPLACE",
+                    "payload": {
+                        "musicFormBooleanChoice": {
+                            "id": "EnJQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9BU0NFTkRJTkcgkQEoAQ%3D%3D",
+                            "parentFormEntityKey": "Ej9QQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UgkAEoAQ%3D%3D",
+                            "selected": false,
+                            "opaqueToken": "SortSpec_Type_ENTITY_NAME_SortSpec_Order_ASCENDING"
+                        }
+                    }
+                },
+                {
+                    "entityKey": "EnNQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9ERVNDRU5ESU5HIJEBKAE%3D",
+                    "type": "ENTITY_MUTATION_TYPE_REPLACE",
+                    "payload": {
+                        "musicFormBooleanChoice": {
+                            "id": "EnNQQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UtU29ydFNwZWNfVHlwZV9FTlRJVFlfTkFNRV9Tb3J0U3BlY19PcmRlcl9ERVNDRU5ESU5HIJEBKAE%3D",
+                            "parentFormEntityKey": "Ej9QQUdFX1RZUEVfTElCUkFSWV9MQU5ESU5HX1BBR0UtUEFHRV9UWVBFX0xJQlJBUllfUExBWUxJU1RTX1BBR0UgkAEoAQ%3D%3D",
+                            "selected": false,
+                            "opaqueToken": "SortSpec_Type_ENTITY_NAME_SortSpec_Order_DESCENDING"
+                        }
+                    }
+                }
+            ],
+            "timestamp": {
+                "seconds": "1777193467",
+                "nanos": 286477427
+            }
+        }
+    }
+}

--- a/scripts/track-processor.js
+++ b/scripts/track-processor.js
@@ -1,5 +1,6 @@
 import { UIHelper } from '../utils/ui-helper.js';
 import { Track } from './models/track.js';
+import { CONSTANTS } from '../utils/constants.js';
 
 /**
  * TrackProcessor - Handles the logic for processing tracks and finding replacements
@@ -27,7 +28,7 @@ export class TrackProcessor {
       }
       item.searchCancelled = false;
       item.replacement = null;
-      this.bridge.ui.addItem(item, this.bridge.constructor.BASE_URL, i++);
+      this.bridge.ui.addItem(item, CONSTANTS.API.BASE_URL, i++);
     }
 
     i = 1;
@@ -54,9 +55,9 @@ export class TrackProcessor {
       }
       
       item.isSearching = false;
-      this.bridge.ui.updateItemRow(item, this.bridge.constructor.BASE_URL, i++);
+      this.bridge.ui.updateItemRow(item, CONSTANTS.API.BASE_URL, i++);
 
-      await this.bridge.sleep(this.bridge.constructor.TIMEOUT_DURATION);
+      await this.bridge.sleep(CONSTANTS.API.TIMEOUT_DURATION_MS);
     }
     
     if (this.bridge.session.isCancelled) {
@@ -64,7 +65,7 @@ export class TrackProcessor {
         if (!itemsToProcess[j - 1].isGeneric && !itemsToProcess[j - 1].isSkipped) {
           itemsToProcess[j - 1].isSearching = false;
           itemsToProcess[j - 1].searchCancelled = true;
-          this.bridge.ui.updateItemRow(itemsToProcess[j - 1], this.bridge.constructor.BASE_URL, j);
+          this.bridge.ui.updateItemRow(itemsToProcess[j - 1], CONSTANTS.API.BASE_URL, j);
         }
       }
     }
@@ -184,7 +185,7 @@ export class TrackProcessor {
         track.isSearching = true;
         track.searchCancelled = false;
         track.replacement = null;
-        this.bridge.ui.addItem(track, this.bridge.constructor.BASE_URL, i++);
+        this.bridge.ui.addItem(track, CONSTANTS.API.BASE_URL, i++);
       }
 
       i = 1;
@@ -205,16 +206,16 @@ export class TrackProcessor {
         }
         
         track.isSearching = false;
-        this.bridge.ui.updateItemRow(track, this.bridge.constructor.BASE_URL, i++);
+        this.bridge.ui.updateItemRow(track, CONSTANTS.API.BASE_URL, i++);
 
-        await this.bridge.sleep(this.bridge.constructor.TIMEOUT_DURATION);
+        await this.bridge.sleep(CONSTANTS.API.TIMEOUT_DURATION_MS);
       }
       
       if (this.bridge.session.isCancelled) {
         for (let j = i; j <= videoTracks.length; j++) {
           videoTracks[j - 1].isSearching = false;
           videoTracks[j - 1].searchCancelled = true;
-          this.bridge.ui.updateItemRow(videoTracks[j - 1], this.bridge.constructor.BASE_URL, j);
+          this.bridge.ui.updateItemRow(videoTracks[j - 1], CONSTANTS.API.BASE_URL, j);
         }
       }
 
@@ -277,7 +278,7 @@ export class TrackProcessor {
         track.isSearching = false;
         track.searchCancelled = false;
         track.replacement = null;
-        this.bridge.ui.addItem(track, this.bridge.constructor.BASE_URL, i++);
+        this.bridge.ui.addItem(track, CONSTANTS.API.BASE_URL, i++);
       }
 
       document.getElementById('replaceSelectedBtn')?.classList.add('hidden');
@@ -307,7 +308,7 @@ export class TrackProcessor {
       this.bridge.ui.toggleSearchProgress(true, false);
       this.bridge.ui.setProgressText('Scanning folder for media files...');
 
-      const mediaExtensions = ['.mp3', '.flac', '.m4a', '.ogg', '.wav', '.aac', '.wma', '.opus'];
+      const mediaExtensions = CONSTANTS.MEDIA.EXTENSIONS;
       const files = [];
 
       await TrackProcessor.#getFilesRecursively(dirHandle, mediaExtensions, files);
@@ -318,7 +319,7 @@ export class TrackProcessor {
       const localTracks = files.map(file => {
         const rawName = file.name.substring(0, file.name.lastIndexOf('.')) || file.name;
         const name = rawName.replace(/[_-]/g, ' ').replace(/\s+/g, ' ').trim();
-        const isGeneric = name.length < 3 || Track.GENERIC_NAME_REGEX.test(name);
+        const isGeneric = name.length < 3 || CONSTANTS.REGEX.GENERIC_NAME.test(name);
         return new Track({
           name: name,
           artists: [],
@@ -332,7 +333,7 @@ export class TrackProcessor {
       this.bridge.localTracks = localTracks;
 
       let i = 1;
-      localTracks.forEach(track => this.bridge.ui.addItem(track, this.bridge.constructor.BASE_URL, i++));
+      localTracks.forEach(track => this.bridge.ui.addItem(track, CONSTANTS.API.BASE_URL, i++));
 
       if (localTracks.length > 0) {
         let progressMsg = `Displayed ${localTracks.length} tracks.`;
@@ -376,7 +377,7 @@ export class TrackProcessor {
 
       const localTracks = lines.map(line => {
         const name = line.trim();
-        const isGeneric = name.length < 3 || Track.GENERIC_NAME_REGEX.test(name);
+        const isGeneric = name.length < 3 || CONSTANTS.REGEX.GENERIC_NAME.test(name);
         return new Track({
           name: name,
           artists: [],
@@ -390,7 +391,7 @@ export class TrackProcessor {
       this.bridge.localTracks = localTracks;
 
       let i = 1;
-      localTracks.forEach(track => this.bridge.ui.addItem(track, this.bridge.constructor.BASE_URL, i++));
+      localTracks.forEach(track => this.bridge.ui.addItem(track, CONSTANTS.API.BASE_URL, i++));
 
       if (localTracks.length > 0) {
         let progressMsg = `Displayed ${localTracks.length} tracks.`;

--- a/scripts/yt-music-api.js
+++ b/scripts/yt-music-api.js
@@ -8,7 +8,8 @@ export class YTMusicAPI {
   // Constants
   static INNERTUBE_ENDPOINT = 'https://music.youtube.com';
   static PLAYLIST_BROWSE_IDS = [
-    'FEmusic_liked_playlists'
+    'FEmusic_liked_playlists',
+    'FEmusic_library_landing'
   ];
   static SIMILARITY_THRESHOLD = 0.5;
 
@@ -105,27 +106,48 @@ export class YTMusicAPI {
   }
 
   /**
-   * Fetches all editable playlists for the current user
+   * Fetches playlists for the current user
    * @async
+   * @param {boolean} onlyEditable - Whether to only return editable playlists
    * @returns {Promise<Array<Playlist>>}
    */
-  async getEditablePlaylists() {
+  async getPlaylists(onlyEditable = false) {
     let lastError = null;
+    const allPlaylists = new Map();
 
     for (const browseId of YTMusicAPI.PLAYLIST_BROWSE_IDS) {
       try {
         const response = await this.fetchBrowsePlaylists(browseId);
-        const playlists = YTMusicParser.parseEditablePlaylistsFromResponse(response);
-        if (playlists.length > 0) {
-          return playlists;
-        }
+        const playlists = YTMusicParser.parsePlaylistsFromResponse(response, onlyEditable);
+        playlists.forEach(p => {
+          if (!allPlaylists.has(p.id)) {
+            allPlaylists.set(p.id, p);
+          } else if (p.isEditable) {
+            // Prefer editable version if duplicate ID found
+            allPlaylists.set(p.id, p);
+          }
+        });
       } catch (error) {
         lastError = error;
       }
     }
 
+    if (allPlaylists.size > 0) {
+      return Array.from(allPlaylists.values());
+    }
+
     if (lastError) throw lastError;
     return [];
+  }
+
+  /**
+   * Fetches all editable playlists for the current user
+   * @deprecated Use getPlaylists(true)
+   * @async
+   * @returns {Promise<Array<Playlist>>}
+   */
+  async getEditablePlaylists() {
+    return this.getPlaylists(true);
   }
 
   /**

--- a/scripts/yt-music-api.js
+++ b/scripts/yt-music-api.js
@@ -1,20 +1,13 @@
 import { YTMusicParser } from './yt-music-parser.js';
+import { CONSTANTS } from '../utils/constants.js';
 
 /**
  * YTMusicAPI - Handles all YouTube Music API interactions
  * Provides methods for playlist management, search, and item manipulation
  */
 export class YTMusicAPI {
-  // Constants
-  static INNERTUBE_ENDPOINT = 'https://music.youtube.com';
-  static PLAYLIST_BROWSE_IDS = [
-    'FEmusic_liked_playlists',
-    'FEmusic_library_landing'
-  ];
-  static SIMILARITY_THRESHOLD = 0.5;
-
   constructor() {
-    this.baseURL = YTMusicAPI.INNERTUBE_ENDPOINT;
+    this.baseURL = CONSTANTS.API.INNERTUBE_ENDPOINT;
     this.authToken = null;
   }
 
@@ -115,7 +108,7 @@ export class YTMusicAPI {
     let lastError = null;
     const allPlaylists = new Map();
 
-    for (const browseId of YTMusicAPI.PLAYLIST_BROWSE_IDS) {
+    for (const browseId of CONSTANTS.API.PLAYLIST_BROWSE_IDS) {
       try {
         const response = await this.fetchBrowsePlaylists(browseId);
         const playlists = YTMusicParser.parsePlaylistsFromResponse(response, onlyEditable);
@@ -237,7 +230,7 @@ export class YTMusicAPI {
    * @param {number} similarityThreshold - Similarity threshold
    * @returns {Track|null}
    */
-  getBestSearchResult(searchResponse, originalQuery, similarityThreshold = YTMusicAPI.SIMILARITY_THRESHOLD) {
+  getBestSearchResult(searchResponse, originalQuery, similarityThreshold = CONSTANTS.API.SIMILARITY_THRESHOLD) {
     return YTMusicParser.getBestSearchResult(searchResponse, originalQuery, similarityThreshold);
   }
 

--- a/scripts/yt-music-parser.js
+++ b/scripts/yt-music-parser.js
@@ -1,12 +1,11 @@
 import { Playlist } from './models/playlist.js';
 import { Track } from './models/track.js';
+import { CONSTANTS } from '../utils/constants.js';
 
 /**
  * YTMusicParser - Handles parsing of YouTube Music API responses
  */
 export class YTMusicParser {
-  static FILTER_TEXTS = [', ', ' & ', ' - ', 'Song', 'Video', ' • '];
-
   /**
    * Parses playlists from API response
    * @param {Object} data - API response data
@@ -128,12 +127,12 @@ export class YTMusicParser {
   static isPlaylistEditable(menuItems) {
     if (!menuItems || !Array.isArray(menuItems)) return false;
     
-    const editKeywords = ['Edit details', 'Delete playlist', 'Rename playlist', 'Edit playlist'];
+    const editKeywords = CONSTANTS.PARSER.EDIT_KEYWORDS;
     
     for (const item of menuItems) {
       const renderer = item?.menuNavigationItemRenderer || item?.menuServiceItemRenderer;
       if (renderer?.text?.runs) {
-        const text = renderer.text.runs.map(run => run?.text || '').join('');
+        const text = renderer.text.runs.map(run => run?.text || '').join('').toLowerCase();
         if (editKeywords.some(keyword => text.includes(keyword))) return true;
       }
       
@@ -215,7 +214,7 @@ export class YTMusicParser {
             ?.text?.runs?.[0]?.text || '';
 
           const artists = musicItemRenderer?.flexColumns?.[1]?.musicResponsiveListItemFlexColumnRenderer
-            ?.text?.runs?.map(run => run.text).filter(text => !this.FILTER_TEXTS.includes(text)) || [];
+            ?.text?.runs?.map(run => run.text).filter(text => !CONSTANTS.PARSER.FILTER_TEXTS.includes(text)) || [];
 
           const album = musicItemRenderer?.flexColumns?.[2]?.musicResponsiveListItemFlexColumnRenderer
             ?.text?.runs?.[0]?.text || '';
@@ -363,7 +362,7 @@ export class YTMusicParser {
 
       const artists = subtitleRuns
         .map(run => run.text)
-        .filter(text => !this.FILTER_TEXTS.includes(text)) || [];
+        .filter(text => !CONSTANTS.PARSER.FILTER_TEXTS.includes(text)) || [];
 
       const album = musicItemRenderer?.flexColumns?.[2]?.musicResponsiveListItemFlexColumnRenderer
         ?.text?.runs?.[0]?.text || '';

--- a/scripts/yt-music-parser.js
+++ b/scripts/yt-music-parser.js
@@ -8,11 +8,12 @@ export class YTMusicParser {
   static FILTER_TEXTS = [', ', ' & ', ' - ', 'Song', 'Video', ' • '];
 
   /**
-   * Parses editable playlists from API response
+   * Parses playlists from API response
    * @param {Object} data - API response data
+   * @param {boolean} onlyEditable - Whether to only return editable playlists
    * @returns {Array<Playlist>}
    */
-  static parseEditablePlaylistsFromResponse(data) {
+  static parsePlaylistsFromResponse(data, onlyEditable = false) {
     const playlists = [];
     if (!data) return playlists;
 
@@ -42,7 +43,9 @@ export class YTMusicParser {
 
         const playlist = this.extractPlaylistFromMusicTwoRowRenderer(renderer);
         if (playlist) {
-          playlists.push(playlist);
+          if (!onlyEditable || playlist.isEditable) {
+            playlists.push(playlist);
+          }
         }
       });
     } catch (error) {
@@ -50,6 +53,13 @@ export class YTMusicParser {
     }
 
     return playlists;
+  }
+
+  /**
+   * Backward compatibility for parseEditablePlaylistsFromResponse
+   */
+  static parseEditablePlaylistsFromResponse(data) {
+    return this.parsePlaylistsFromResponse(data, true);
   }
 
   /**
@@ -75,8 +85,19 @@ export class YTMusicParser {
    */
   static extractPlaylistFromMusicTwoRowRenderer(renderer) {
     const menuItems = renderer?.menu?.menuRenderer?.items || [];
-    const playlistId = this.getPlaylistIdFromMenuItems(menuItems);
-    if (!playlistId) return null;
+    const playlistInfo = this.getPlaylistInfoFromMenuItems(menuItems);
+    
+    let id = playlistInfo.id;
+    if (!id) {
+      // Fallback: try to get ID from renderer's own navigation endpoint
+      const endpoint = renderer?.navigationEndpoint;
+      id = endpoint?.browseEndpoint?.browseId || endpoint?.watchPlaylistEndpoint?.playlistId;
+    }
+    
+    if (!id) return null;
+    
+    // Cleanup ID (strip VL prefix if present)
+    if (id.startsWith('VL')) id = id.substring(2);
 
     const title = this.parseTextField(renderer?.title);
     if (!title) return null;
@@ -86,30 +107,82 @@ export class YTMusicParser {
     const owner = subtitleRuns?.[0]?.text || '';
     const thumbnail = renderer?.thumbnailRenderer?.musicThumbnailRenderer?.thumbnail?.thumbnails?.slice(-1)?.[0]?.url || '';
 
+    // Final editability check using menu text runs as well
+    const isEditable = playlistInfo.isEditable || this.isPlaylistEditable(menuItems);
+
     return new Playlist({
-      id: playlistId,
+      id,
       title,
       subtitle,
       owner,
-      thumbnail
+      thumbnail,
+      isEditable
     });
   }
 
   /**
-   * Extracts playlist ID from menu items
+   * Checks if a playlist is editable based on menu items
+   * @param {Array} menuItems - Array of menu items
+   * @returns {boolean}
    */
-  static getPlaylistIdFromMenuItems(menuItems) {
+  static isPlaylistEditable(menuItems) {
+    if (!menuItems || !Array.isArray(menuItems)) return false;
+    
+    const editKeywords = ['Edit details', 'Delete playlist', 'Rename playlist', 'Edit playlist'];
+    
+    for (const item of menuItems) {
+      const renderer = item?.menuNavigationItemRenderer || item?.menuServiceItemRenderer;
+      if (renderer?.text?.runs) {
+        const text = renderer.text.runs.map(run => run?.text || '').join('');
+        if (editKeywords.some(keyword => text.includes(keyword))) return true;
+      }
+      
+      const endpoint = renderer?.navigationEndpoint || renderer?.serviceEndpoint;
+      if (endpoint?.playlistEditorEndpoint || endpoint?.playlistEditEndpoint) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Extracts playlist info (ID and editability) from menu items
+   */
+  static getPlaylistInfoFromMenuItems(menuItems) {
+    let id = null;
+    let isEditable = false;
+
     for (const menuItem of menuItems) {
-      const endpoint = menuItem?.menuNavigationItemRenderer?.navigationEndpoint || menuItem?.navigationEndpoint;
+      const renderer = menuItem?.menuNavigationItemRenderer || menuItem?.menuServiceItemRenderer || menuItem?.toggleMenuServiceItemRenderer;
+      if (!renderer) continue;
+
+      const endpoint = renderer?.navigationEndpoint || renderer?.serviceEndpoint || renderer?.defaultServiceEndpoint;
       if (!endpoint) continue;
 
       const playlistId = endpoint?.playlistEditorEndpoint?.playlistId
         || endpoint?.playlistEditEndpoint?.playlistId
-        || endpoint?.browseEndpoint?.browseId;
+        || endpoint?.browseEndpoint?.browseId
+        || endpoint?.watchPlaylistEndpoint?.playlistId
+        || endpoint?.addToPlaylistEndpoint?.playlistId
+        || endpoint?.queueAddEndpoint?.queueTarget?.playlistId
+        || endpoint?.likeEndpoint?.target?.playlistId;
 
-      if (playlistId) return playlistId;
+      if (playlistId) {
+        id = playlistId;
+      }
+
+      if (endpoint?.playlistEditorEndpoint || endpoint?.playlistEditEndpoint) {
+        isEditable = true;
+      }
     }
-    return null;
+
+    return { id, isEditable };
+  }
+
+  /**
+   * Extracts playlist ID from menu items
+   * @deprecated Use getPlaylistInfoFromMenuItems
+   */
+  static getPlaylistIdFromMenuItems(menuItems) {
+    return this.getPlaylistInfoFromMenuItems(menuItems).id;
   }
 
   /**

--- a/styles/in-site-popup.css
+++ b/styles/in-site-popup.css
@@ -79,7 +79,8 @@
 .playlist-controls-wrapper {
     display: flex;
     justify-content: flex-end;
-    margin-bottom: 12px;
+    margin-top: 12px;
+    gap: 12px;
 }
 
 .close-btn, .minimize-btn {

--- a/tests/scripts/yt-music-parser.test.js
+++ b/tests/scripts/yt-music-parser.test.js
@@ -117,4 +117,33 @@ describe('YTMusicParser', () => {
       expect(YTMusicParser.parseTextField({ runs: [{ text: 'a' }, { text: 'b' }] })).toBe('ab');
     });
   });
+
+  describe('isPlaylistEditable', () => {
+    it('should return true if an edit keyword is found (case-insensitive)', () => {
+      const menuItems = [{
+        menuNavigationItemRenderer: {
+          text: { runs: [{ text: 'EDIT PLAYLIST' }] }
+        }
+      }];
+      expect(YTMusicParser.isPlaylistEditable(menuItems)).toBe(true);
+    });
+
+    it('should return true if an edit endpoint is found', () => {
+      const menuItems = [{
+        menuNavigationItemRenderer: {
+          navigationEndpoint: { playlistEditorEndpoint: {} }
+        }
+      }];
+      expect(YTMusicParser.isPlaylistEditable(menuItems)).toBe(true);
+    });
+
+    it('should return false if no edit markers are found', () => {
+      const menuItems = [{
+        menuNavigationItemRenderer: {
+          text: { runs: [{ text: 'Add to queue' }] }
+        }
+      }];
+      expect(YTMusicParser.isPlaylistEditable(menuItems)).toBe(false);
+    });
+  });
 });

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -1,0 +1,53 @@
+/**
+ * Constants used across the YouTube Music Plus extension
+ */
+
+export const CONSTANTS = {
+  PLAYER: {
+    MAX_RETRIES: 10,
+    RETRY_INTERVAL_MS: 1000,
+    SEEK_DURATION_SECONDS: 10,
+  },
+  UI: {
+    STATUS_DURATION_MS: 3000,
+    DEBOUNCE_DELAY_MS: 300,
+    THROTTLE_LIMIT_MS: 300,
+    ISSUE_URL: 'https://chromewebstore.google.com/detail/lkieghnbgfnidfhdeclkjkmnjokmkmdc/support',
+  },
+  SETTINGS: {
+    DEFAULT: {
+      showNavButton: true,
+      showPlaylistButton: true,
+      loadAllPlaylists: false,
+      hideWarningMessage: false
+    }
+  },
+  API: {
+    INNERTUBE_ENDPOINT: 'https://music.youtube.com',
+    PLAYLIST_BROWSE_IDS: [
+      'FEmusic_liked_playlists',
+      'FEmusic_library_landing'
+    ],
+    SIMILARITY_THRESHOLD: 0.5,
+    JARO_WINKLER_PREFIX_LEN: 4,
+    JARO_WINKLER_SCALING_FACTOR: 0.1,
+    TIMEOUT_DURATION_MS: 100,
+    PAGE_LOAD_TIMEOUT_MS: 3000,
+    BASE_URL: 'https://music.youtube.com/watch?v=',
+    PLAYLIST_PAGE_PATH: 'https://music.youtube.com/playlist',
+  },
+  PARSER: {
+    FILTER_TEXTS: [', ', ' & ', ' - ', 'Song', 'Video', ' • '],
+    EDIT_KEYWORDS: ['edit details', 'delete playlist', 'rename playlist', 'edit playlist'],
+  },
+  REGEX: {
+    GENERIC_NAME: /^\d*\s*(?:-|_)?\s*(?:(?:unknown|untitled|misc)(?:\s*artist)?\s*(?:-|_)?\s*)?(?:track|audio\s*track|unknown|untitled|misc)\s*\d*$/i,
+    VIDEO_SUFFIX: /(official\s*)?(music\s*)?video/gi,
+  },
+  MEDIA: {
+    EXTENSIONS: ['.mp3', '.flac', '.m4a', '.ogg', '.wav', '.aac', '.wma', '.opus'],
+  },
+  STORAGE_KEYS: {
+    // Add storage keys here if needed
+  }
+};

--- a/utils/ui-helper.js
+++ b/utils/ui-helper.js
@@ -1,4 +1,5 @@
 import { TextSimilarity, Formatters, BrowserUtils } from './utils.js';
+import { CONSTANTS } from './constants.js';
 
 /**
  * MediaItem - Represents a track/item UI component
@@ -47,8 +48,8 @@ export class MediaItem {
 
       bindControl('.btn-play', () => playerHandler.playTrack(media.videoId));
       bindControl('.btn-pause', () => playerHandler.pauseTrack());
-      bindControl('.btn-seek-back', () => playerHandler.seekBy(-10));
-      bindControl('.btn-seek-forward', () => playerHandler.seekBy(10));
+      bindControl('.btn-seek-back', () => playerHandler.seekBy(-CONSTANTS.PLAYER.SEEK_DURATION_SECONDS));
+      bindControl('.btn-seek-forward', () => playerHandler.seekBy(CONSTANTS.PLAYER.SEEK_DURATION_SECONDS));
     } else {
       controls?.remove();
     }
@@ -186,7 +187,7 @@ export class PlaylistCard {
  * UIHelper - Handles high-level UI operations and state management
  */
 export class UIHelper {
-  static ISSUE_URL = 'https://chromewebstore.google.com/detail/lkieghnbgfnidfhdeclkjkmnjokmkmdc/support';
+  static ISSUE_URL = CONSTANTS.UI.ISSUE_URL;
 
   /**
    * Shorthand for document.createElement with optional configuration.
@@ -214,9 +215,9 @@ export class UIHelper {
    * @param {Element} element
    * @param {string} message
    * @param {'success'|'error'|'info'} [type='info']
-   * @param {number} [duration=3000]
+   * @param {number} [duration=CONSTANTS.UI.STATUS_DURATION_MS]
    */
-  static showStatus(element, message, type = 'info', duration = 3000) {
+  static showStatus(element, message, type = 'info', duration = CONSTANTS.UI.STATUS_DURATION_MS) {
     if (!element) return;
 
     element.textContent = message;

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -1,3 +1,5 @@
+import { CONSTANTS } from './constants.js';
+
 /**
  * Generic Utility functions refactored into classes
  */
@@ -52,12 +54,12 @@ export class TextSimilarity {
       (matches / s1Len + matches / s2Len + (matches - transpositions) / matches) / 3;
     
     let prefixLen = 0;
-    for (let i = 0; i < Math.min(4, s1Len, s2Len); i++) {
+    for (let i = 0; i < Math.min(CONSTANTS.API.JARO_WINKLER_PREFIX_LEN, s1Len, s2Len); i++) {
       if (s1[i] === s2[i]) prefixLen++;
       else break;
     }
 
-    const scaling = 0.1;
+    const scaling = CONSTANTS.API.JARO_WINKLER_SCALING_FACTOR;
     return jaro + prefixLen * scaling * (1 - jaro);
   }
 
@@ -67,10 +69,10 @@ export class TextSimilarity {
    *
    * @param {string} originalTitle
    * @param {string} replacementTitle
-   * @param {number} [similarityThreshold=0.5]
+   * @param {number} [similarityThreshold=CONSTANTS.API.SIMILARITY_THRESHOLD]
    * @returns {boolean}
    */
-  static isGoodMatch(originalTitle, replacementTitle, similarityThreshold = 0.5) {
+  static isGoodMatch(originalTitle, replacementTitle, similarityThreshold = CONSTANTS.API.SIMILARITY_THRESHOLD) {
     if (!replacementTitle) {
       return false;
     }
@@ -138,10 +140,10 @@ export class BrowserUtils {
    * Return a debounced version of `func` that fires after `delay` ms have passed
    * since the last call. Useful for limiting expensive event handlers.
    * @param {Function} func
-   * @param {number} [delay=300]
+   * @param {number} [delay=CONSTANTS.UI.DEBOUNCE_DELAY_MS]
    * @returns {Function}
    */
-  static debounce(func, delay = 300) {
+  static debounce(func, delay = CONSTANTS.UI.DEBOUNCE_DELAY_MS) {
     let timeoutId;
     return (...args) => {
       clearTimeout(timeoutId);
@@ -153,10 +155,10 @@ export class BrowserUtils {
    * Throttles `func` so that it can only be invoked once every `limit` ms.
    * Handy for scroll/resize callbacks.
    * @param {Function} func
-   * @param {number} [limit=300]
+   * @param {number} [limit=CONSTANTS.UI.THROTTLE_LIMIT_MS]
    * @returns {Function}
    */
-  static throttle(func, limit = 300) {
+  static throttle(func, limit = CONSTANTS.UI.THROTTLE_LIMIT_MS) {
     let inThrottle = false;
     return (...args) => {
       if (!inThrottle) {


### PR DESCRIPTION
- Add 'Always load all playlists' setting to extension options.
- Implement robust playlist editability detection using keywords and endpoints.
- Support playlist ID extraction for users without a YouTube channel.
- Update UI with separate buttons for loading editable vs all playlists.
- Improve popup styling with better button spacing and margins.
- Synchronize extension settings across all active tabs via background script.