### PR TITLE
feat: playback for local imported files

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -72,8 +72,9 @@ This document provides a comprehensive list of features for the YouTube Music + 
 - **Behavior**:
     - Parses file names to create a search list.
     - Filters out "generic" or short filenames (e.g., "track 01").
+    - **Preview Playback**: Allows users to preview local audio files directly in the popup before searching.
     - Allows users to search for these tracks on YTM.
-- **Testable Case**: Select a local folder; verify files are listed; click "Start Search" to find them on YTM.
+- **Testable Case**: Select a local folder; verify files are listed; hover over a track and click "Play" to preview; click "Start Search" to find them on YTM.
 
 ### 2.5 Import from File
 - **Feature**: Reads a `.txt` file where each line is a song title.

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -103,6 +103,7 @@ import { CONSTANTS } from '../utils/constants.js';
       this.thumbnail = item.thumbnail;
       this.url = item.videoId ? baseUrl + item.videoId : null;
       this.videoId = item.videoId;
+      this.localFile = item.localFile;
       this.playlistSetVideoId = item.playlistSetVideoId;
       this.isGoodMatch = item.isGoodMatch;
       this.isPending = false;

--- a/scripts/models/track.js
+++ b/scripts/models/track.js
@@ -21,6 +21,7 @@ export class Track {
    * @param {boolean} [params.isSearching] - Current search status
    * @param {boolean} [params.searchCancelled] - Whether searching was cancelled
    * @param {boolean} [params.isSkipped] - Whether the track was skipped during processing
+   * @param {File} [params.localFile] - The actual File object for local tracks
    * @param {Track|Object} [params.replacement] - Found replacement track
    */
   constructor({
@@ -38,6 +39,7 @@ export class Track {
     isSearching = false,
     searchCancelled = false,
     isSkipped = false,
+    localFile = null,
     replacement = null
   }) {
     this.name = name;
@@ -54,6 +56,7 @@ export class Track {
     this.isSearching = isSearching;
     this.searchCancelled = searchCancelled;
     this.isSkipped = isSkipped;
+    this.localFile = localFile;
     
     this.replacement = null;
     if (replacement) {

--- a/scripts/player-handler.js
+++ b/scripts/player-handler.js
@@ -9,6 +9,8 @@ export class PlayerHandler {
     this.initialized = false;
     this.retryCount = 0;
     this.maxRetries = CONSTANTS.PLAYER.MAX_RETRIES;
+    this.localPlayer = null;
+    this.currentLocalFile = null;
   }
 
   /**
@@ -44,6 +46,9 @@ export class PlayerHandler {
    * Playback actions
    */
   playTrack(videoId) {
+    // Stop local player if running
+    this.pauseLocalTrack();
+
     const playerApi = this.api;
     if (!playerApi) return;
     
@@ -56,12 +61,44 @@ export class PlayerHandler {
     }
   }
 
+  playLocalFile(file) {
+    if (!file) return;
+
+    // Pause YouTube player
+    this.api?.pauseVideo();
+
+    if (!this.localPlayer) {
+      this.localPlayer = new Audio();
+    }
+
+    if (this.currentLocalFile !== file) {
+      if (this.localPlayer.src) {
+        URL.revokeObjectURL(this.localPlayer.src);
+      }
+      this.localPlayer.src = URL.createObjectURL(file);
+      this.currentLocalFile = file;
+    }
+
+    this.localPlayer.play();
+  }
+
   pauseTrack() {
     this.api?.pauseVideo();
+    this.pauseLocalTrack();
+  }
+
+  pauseLocalTrack() {
+    if (this.localPlayer && !this.localPlayer.paused) {
+      this.localPlayer.pause();
+    }
   }
 
   seekBy(seconds) {
-    this.api?.seekBy(seconds);
+    if (this.localPlayer && !this.localPlayer.paused) {
+      this.localPlayer.currentTime += seconds;
+    } else {
+      this.api?.seekBy(seconds);
+    }
   }
 
   /**
@@ -112,6 +149,18 @@ export class PlayerHandler {
    * @returns {number} Value from CONSTANTS.PLAYER.STATE
    */
   getPlayerState() {
+    if (this.localPlayer && !this.localPlayer.paused) {
+      return CONSTANTS.PLAYER.STATE.PLAYING;
+    }
     return this.api?.getPlayerState() ?? CONSTANTS.PLAYER.STATE.UNSTARTED;
+  }
+
+  /**
+   * Checks if a local file is currently playing
+   * @param {File} file 
+   * @returns {boolean}
+   */
+  isLocalFilePlaying(file) {
+    return this.localPlayer && !this.localPlayer.paused && this.currentLocalFile === file;
   }
 }

--- a/scripts/player-handler.js
+++ b/scripts/player-handler.js
@@ -11,6 +11,7 @@ export class PlayerHandler {
     this.maxRetries = CONSTANTS.PLAYER.MAX_RETRIES;
     this.localPlayer = null;
     this.currentLocalFile = null;
+    this.activeSource = CONSTANTS.PLAYER.SOURCE.YOUTUBE;
   }
 
   /**
@@ -48,6 +49,7 @@ export class PlayerHandler {
   playTrack(videoId) {
     // Stop local player if running
     this.pauseLocalTrack();
+    this.activeSource = CONSTANTS.PLAYER.SOURCE.YOUTUBE;
 
     const playerApi = this.api;
     if (!playerApi) return;
@@ -66,9 +68,15 @@ export class PlayerHandler {
 
     // Pause YouTube player
     this.api?.pauseVideo();
+    this.activeSource = CONSTANTS.PLAYER.SOURCE.LOCAL;
 
     if (!this.localPlayer) {
       this.localPlayer = new Audio();
+      
+      // Add event listener to handle ended state
+      this.localPlayer.addEventListener('ended', () => {
+        // You might want to trigger next track here in the future
+      });
     }
 
     if (this.currentLocalFile !== file) {
@@ -79,7 +87,10 @@ export class PlayerHandler {
       this.currentLocalFile = file;
     }
 
-    this.localPlayer.play();
+    this.localPlayer.play().catch(error => {
+      console.error('PlayerHandler: Local playback failed', error);
+      this.activeSource = CONSTANTS.PLAYER.SOURCE.YOUTUBE;
+    });
   }
 
   pauseTrack() {
@@ -94,7 +105,7 @@ export class PlayerHandler {
   }
 
   seekBy(seconds) {
-    if (this.localPlayer && !this.localPlayer.paused) {
+    if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
       this.localPlayer.currentTime += seconds;
     } else {
       this.api?.seekBy(seconds);
@@ -117,30 +128,47 @@ export class PlayerHandler {
   }
 
   getVolume() {
+    if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
+      return this.localPlayer.volume * 100;
+    }
     return this.api?.getVolume() || 0;
   }
 
   setVolume(volume) {
+    if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
+      this.localPlayer.volume = volume / 100;
+    }
     this.api?.setVolume(volume);
   }
 
   isMuted() {
+    if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
+      return this.localPlayer.muted;
+    }
     return this.api?.isMuted() || false;
   }
 
   mute() {
+    if (this.localPlayer) this.localPlayer.muted = true;
     this.api?.mute();
   }
 
   unMute() {
+    if (this.localPlayer) this.localPlayer.muted = false;
     this.api?.unMute();
   }
 
   getCurrentTime() {
+    if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
+      return this.localPlayer.currentTime;
+    }
     return this.api?.getCurrentTime() || 0;
   }
 
   getDuration() {
+    if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
+      return this.localPlayer.duration || 0;
+    }
     return this.api?.getDuration() || 0;
   }
 
@@ -149,8 +177,9 @@ export class PlayerHandler {
    * @returns {number} Value from CONSTANTS.PLAYER.STATE
    */
   getPlayerState() {
-    if (this.localPlayer && !this.localPlayer.paused) {
-      return CONSTANTS.PLAYER.STATE.PLAYING;
+    if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
+      if (this.localPlayer.ended) return CONSTANTS.PLAYER.STATE.ENDED;
+      return this.localPlayer.paused ? CONSTANTS.PLAYER.STATE.PAUSED : CONSTANTS.PLAYER.STATE.PLAYING;
     }
     return this.api?.getPlayerState() ?? CONSTANTS.PLAYER.STATE.UNSTARTED;
   }
@@ -161,6 +190,9 @@ export class PlayerHandler {
    * @returns {boolean}
    */
   isLocalFilePlaying(file) {
-    return this.localPlayer && !this.localPlayer.paused && this.currentLocalFile === file;
+    return this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && 
+           this.localPlayer && 
+           !this.localPlayer.paused && 
+           this.currentLocalFile === file;
   }
 }

--- a/scripts/track-processor.js
+++ b/scripts/track-processor.js
@@ -325,6 +325,7 @@ export class TrackProcessor {
           artists: [],
           album: '',
           isLocal: true,
+          localFile: file,
           isSearching: !isGeneric,
           isGeneric: isGeneric
         });

--- a/tests/scripts/models.test.js
+++ b/tests/scripts/models.test.js
@@ -42,6 +42,18 @@ describe('Track Class', () => {
     expect(track.toSearchQuery()).toBe('Song - Album - Artist 1, Artist 2');
   });
 
+  it('should handle local file correctly', () => {
+    const mockFile = { name: 'test.mp3' };
+    const track = new Track({
+      name: 'Local Song',
+      isLocal: true,
+      localFile: mockFile
+    });
+
+    expect(track.isLocal).toBe(true);
+    expect(track.localFile).toBe(mockFile);
+  });
+
   it('should handle replacement as a Track instance', () => {
     const replacementData = { name: 'Replacement' };
     const track = new Track({

--- a/tests/scripts/player-handler.test.js
+++ b/tests/scripts/player-handler.test.js
@@ -188,4 +188,51 @@ describe('PlayerHandler', () => {
 
     expect(handler.getPlayerState()).toBe(CONSTANTS.PLAYER.STATE.PLAYING);
   });
+
+  describe('Local playback', () => {
+    it('should play local file and pause YouTube player', () => {
+      const mockApi = { pauseVideo: vi.fn() };
+      const mockApp = document.createElement('ytmusic-app');
+      mockApp.playerApi = mockApi;
+      document.body.appendChild(mockApp);
+
+      const mockFile = new File([''], 'test.mp3', { type: 'audio/mpeg' });
+      
+      // Mock Audio play and paused property
+      const playSpy = vi.spyOn(Audio.prototype, 'play').mockImplementation(function() {
+        vi.spyOn(this, 'paused', 'get').mockReturnValue(false);
+        return Promise.resolve();
+      });
+      
+      handler.playLocalFile(mockFile);
+
+      expect(mockApi.pauseVideo).toHaveBeenCalled();
+      expect(playSpy).toHaveBeenCalled();
+      expect(handler.isLocalFilePlaying(mockFile)).toBe(true);
+    });
+
+    it('should pause local playback', () => {
+      const mockFile = new File([''], 'test.mp3', { type: 'audio/mpeg' });
+      const pauseSpy = vi.spyOn(Audio.prototype, 'pause').mockImplementation(() => {});
+      
+      // Simulate playing
+      handler.localPlayer = new Audio();
+      handler.currentLocalFile = mockFile;
+      vi.spyOn(handler.localPlayer, 'paused', 'get').mockReturnValue(false);
+
+      handler.pauseLocalTrack();
+      expect(pauseSpy).toHaveBeenCalled();
+    });
+
+    it('should seek local playback', () => {
+      const mockFile = new File([''], 'test.mp3', { type: 'audio/mpeg' });
+      handler.localPlayer = new Audio();
+      handler.currentLocalFile = mockFile;
+      vi.spyOn(handler.localPlayer, 'paused', 'get').mockReturnValue(false);
+      handler.localPlayer.currentTime = 10;
+
+      handler.seekBy(5);
+      expect(handler.localPlayer.currentTime).toBe(15);
+    });
+  });
 });

--- a/tests/scripts/player-handler.test.js
+++ b/tests/scripts/player-handler.test.js
@@ -211,6 +211,21 @@ describe('PlayerHandler', () => {
       expect(handler.isLocalFilePlaying(mockFile)).toBe(true);
     });
 
+    it('should handle local playback failure', async () => {
+      const mockFile = new File([''], 'test.mp3', { type: 'audio/mpeg' });
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      
+      vi.spyOn(Audio.prototype, 'play').mockRejectedValue(new Error('Playback failed'));
+      
+      handler.playLocalFile(mockFile);
+      
+      // Wait for promise rejection to be handled
+      await vi.runAllTimersAsync();
+      
+      expect(consoleSpy).toHaveBeenCalledWith('PlayerHandler: Local playback failed', expect.any(Error));
+      expect(handler.activeSource).toBe(CONSTANTS.PLAYER.SOURCE.YOUTUBE);
+    });
+
     it('should pause local playback', () => {
       const mockFile = new File([''], 'test.mp3', { type: 'audio/mpeg' });
       const pauseSpy = vi.spyOn(Audio.prototype, 'pause').mockImplementation(() => {});
@@ -218,6 +233,7 @@ describe('PlayerHandler', () => {
       // Simulate playing
       handler.localPlayer = new Audio();
       handler.currentLocalFile = mockFile;
+      handler.activeSource = CONSTANTS.PLAYER.SOURCE.LOCAL;
       vi.spyOn(handler.localPlayer, 'paused', 'get').mockReturnValue(false);
 
       handler.pauseLocalTrack();
@@ -228,6 +244,7 @@ describe('PlayerHandler', () => {
       const mockFile = new File([''], 'test.mp3', { type: 'audio/mpeg' });
       handler.localPlayer = new Audio();
       handler.currentLocalFile = mockFile;
+      handler.activeSource = CONSTANTS.PLAYER.SOURCE.LOCAL;
       vi.spyOn(handler.localPlayer, 'paused', 'get').mockReturnValue(false);
       handler.localPlayer.currentTime = 10;
 

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -7,6 +7,10 @@ export const CONSTANTS = {
     MAX_RETRIES: 10,
     RETRY_INTERVAL_MS: 1000,
     SEEK_DURATION_SECONDS: 10,
+    SOURCE: {
+      YOUTUBE: 'youtube',
+      LOCAL: 'local'
+    },
     STATE: {
       UNSTARTED: -1,
       ENDED: 0,

--- a/utils/ui-helper.js
+++ b/utils/ui-helper.js
@@ -31,8 +31,8 @@ export class MediaItem {
       thumb.remove();
     }
 
-    // Setup player controls if playerHandler and videoId are provided
-    if (playerHandler && media.videoId && controls) {
+    // Setup player controls if playerHandler and (videoId or localFile) are provided
+    if (playerHandler && (media.videoId || media.localFile) && controls) {
       controls.classList.remove('hidden');
       
       const bindControl = (selector, action) => {
@@ -47,10 +47,16 @@ export class MediaItem {
       };
 
       const updateButtonVisibility = () => {
-        const currentVideoData = playerHandler.getVideoData();
-        const playerState = playerHandler.getPlayerState();
-        const isCurrentTrack = currentVideoData && currentVideoData.video_id === media.videoId;
-        const isPlaying = isCurrentTrack && playerState === CONSTANTS.PLAYER.STATE.PLAYING;
+        let isPlaying = false;
+        
+        if (media.localFile) {
+          isPlaying = playerHandler.isLocalFilePlaying(media.localFile);
+        } else if (media.videoId) {
+          const currentVideoData = playerHandler.getVideoData();
+          const playerState = playerHandler.getPlayerState();
+          const isCurrentTrack = currentVideoData && currentVideoData.video_id === media.videoId;
+          isPlaying = isCurrentTrack && playerState === CONSTANTS.PLAYER.STATE.PLAYING;
+        }
 
         const playBtn = controls.querySelector('.btn-play');
         const pauseBtn = controls.querySelector('.btn-pause');
@@ -60,7 +66,12 @@ export class MediaItem {
       };
 
       bindControl('.btn-play', () => {
-        playerHandler.playTrack(media.videoId);
+        if (media.localFile) {
+          playerHandler.playLocalFile(media.localFile);
+        } else {
+          playerHandler.playTrack(media.videoId);
+        }
+        
         // Immediate optimistic update
         const playBtn = controls.querySelector('.btn-play');
         const pauseBtn = controls.querySelector('.btn-pause');


### PR DESCRIPTION
This PR adds the ability to play local audio files imported via the 'Import from Folder' feature.

Key changes:
- **Local Playback**: Integrated a local audio player into `PlayerHandler` that handles `File` objects from the File System Access API.
- **UI Integration**: The playback controls in the media grid now support local files, allowing users to preview their local tracks before searching for them on YouTube Music.
- **Model Updates**: Extended the `Track` model to preserve the original `File` reference.
- **Tests**: Added comprehensive tests for local playback, seeking, and state management.

Verified with existing and new tests.