### PR TITLE
feat: add auto-list all tracks setting

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -42,6 +42,7 @@ This document provides a comprehensive list of features for the YouTube Music + 
     - Toggle Navigation Button.
     - Toggle Playlist Page Button.
     - **Always load all playlists**: When enabled, the extension fetches all playlists from the user's library by default instead of only editable ones.
+    - **Automatically list all tracks on playlist selection**: When enabled (default), the extension will automatically trigger "List All Tracks" when a playlist is selected, provided no other action is currently active.
     - Reset "Hide Warning Message" state.
     - Save/Reset to Defaults buttons.
 - **Testable Case**: Change a setting, save, and verify the UI updates accordingly on music.youtube.com.
@@ -55,6 +56,7 @@ This document provides a comprehensive list of features for the YouTube Music + 
 - **Refresh Options**:
     - **Load Editable Playlists**: Re-fetches only the playlists that the user has permission to edit.
     - **Load All Playlists**: Fetches all playlists found in the user's library, including liked playlists and albums added as playlists.
+- **Auto-Listing**: By default, selecting a playlist from the grid will automatically fetch and display all its tracks if no other button is active. This behavior can be toggled in Settings.
 - **Default Behavior**: Defaults to editable playlists unless "Always load all playlists" is enabled in settings.
 - **Testable Case**: Click "Load Editable Playlists" and verify only owned/editable playlists appear; click "Load All Playlists" and verify a broader set of playlists is loaded.
 

--- a/options.html
+++ b/options.html
@@ -225,6 +225,14 @@
             </label>
             <p class="info-text">When enabled, the extension will fetch all playlists from your library by default (including non-editable ones). Default is editable playlists only.</p>
           </div>
+
+          <div class="setting-group">
+            <label>
+              <input type="checkbox" id="autoListAllTracks" name="autoListAllTracks">
+              Automatically list all tracks on playlist selection
+            </label>
+            <p class="info-text">When enabled, the extension will automatically display all tracks when you select a playlist if no other actions are active.</p>
+          </div>
         </section>
 
         <div id="statusMessage" class="status-message"></div>

--- a/scripts/bridge-ui.js
+++ b/scripts/bridge-ui.js
@@ -48,9 +48,17 @@ export class BridgeUI {
    * Clears the active state from all playlist action buttons
    */
   clearActiveButtons() {
-    document.querySelectorAll(`.${CONSTANTS.UI.CLASSES.PLAYLIST_ACTION_BUTTONS} .${CONSTANTS.UI.CLASSES.BTN}.${CONSTANTS.UI.CLASSES.ACTIVE}`).forEach(btn => {
+    document.querySelectorAll(CONSTANTS.UI.SELECTORS.ACTIVE_ACTION_BUTTON).forEach(btn => {
       btn.classList.remove(CONSTANTS.UI.CLASSES.ACTIVE);
     });
+  }
+
+  /**
+   * Checks if any playlist action button is currently active
+   * @returns {boolean} True if a button is active
+   */
+  hasActiveActionButton() {
+    return !!document.querySelector(CONSTANTS.UI.SELECTORS.ACTIVE_ACTION_BUTTON);
   }
 
   /**

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -529,8 +529,7 @@ import { CONSTANTS } from '../utils/constants.js';
       }
 
       // Auto-list tracks if enabled and no button is active
-      const hasActiveButton = document.querySelector(`.${CONSTANTS.UI.CLASSES.PLAYLIST_ACTION_BUTTONS} .${CONSTANTS.UI.CLASSES.BTN}.${CONSTANTS.UI.CLASSES.ACTIVE}`);
-      if (this.extSettings?.autoListAllTracks !== false && !hasActiveButton) {
+      if (this.extSettings?.autoListAllTracks !== false && !this.ui.hasActiveActionButton()) {
         this.processor.listAllTracks();
         this.ui.setActiveButton(CONSTANTS.UI.BUTTON_IDS.LIST_ALL_TRACKS);
       }

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -527,6 +527,13 @@ import { CONSTANTS } from '../utils/constants.js';
         document.getElementById(CONSTANTS.UI.ELEMENT_IDS.CLEAR_SEARCH_BTN)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
         this.ui.filterGridItems('');
       }
+
+      // Auto-list tracks if enabled and no button is active
+      const hasActiveButton = document.querySelector(`.${CONSTANTS.UI.CLASSES.PLAYLIST_ACTION_BUTTONS} .${CONSTANTS.UI.CLASSES.BTN}.${CONSTANTS.UI.CLASSES.ACTIVE}`);
+      if (this.extSettings?.autoListAllTracks !== false && !hasActiveButton) {
+        this.processor.listAllTracks();
+        this.ui.setActiveButton(CONSTANTS.UI.BUTTON_IDS.LIST_ALL_TRACKS);
+      }
     }
 
     /**

--- a/scripts/track-processor.js
+++ b/scripts/track-processor.js
@@ -269,6 +269,12 @@ export class TrackProcessor {
       if (!currentPlaylistId) return;
 
       const items = await this.ytMusicAPI.getPlaylistItems(currentPlaylistId);
+      
+      // Race condition check: Verify if we are still on the same playlist
+      if (this.bridge.currentSelectedPlaylist?.id !== currentPlaylistId) {
+        return;
+      }
+
       this.bridge.ui.setProgressText(`Found ${items.length} tracks. Select tracks to remove.`);
 
       if (items.length === 0) return;

--- a/styles/in-site-popup.css
+++ b/styles/in-site-popup.css
@@ -300,7 +300,7 @@
 }
 
 .btn-primary:hover:not(:disabled),
-.btn-primary.active:not(:disabled) {
+.btn-primary.active {
     background-color: white;
     color: black;
 }

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -90,6 +90,7 @@ export const CONSTANTS = {
       showNavButton: true,
       showPlaylistButton: true,
       loadAllPlaylists: false,
+      autoListAllTracks: true,
       hideWarningMessage: false
     }
   },

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -83,6 +83,7 @@ export const CONSTANTS = {
     SELECTORS: {
       YT_MUSIC_HEADER: 'ytmusic-responsive-header-renderer',
       ITEMS_GRID_CHECKBOXES: '#yt-music-plus-itemsGridContainer .item-checkbox',
+      ACTIVE_ACTION_BUTTON: '.playlist-action-buttons .btn.active',
     }
   },
   SETTINGS: {


### PR DESCRIPTION
This PR adds a new setting to automatically list all tracks when a playlist is selected if no other actions are active. The setting is enabled by default and can be toggled in the options page.