### PR TITLE
feat: target playlist selection for track imports

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -89,6 +89,16 @@ This document provides a comprehensive list of features for the YouTube Music + 
 - **Use Case**: Intended for bulk deletion or general management.
 - **Testable Case**: Click "List All Tracks"; verify all tracks are displayed in the grid.
 
+### 2.7 Target Playlist Selection
+- **Feature**: Allows selecting a different target playlist for track importation.
+- **Behavior**:
+    - Appears when importing from a local folder or file.
+    - Displays the currently active playlist as the default target.
+    - "Change" button opens the playlist selection screen to pick a different target.
+    - "Cancel" button in the selection screen allows returning without changing the target.
+    - Respects user settings for loading editable or all playlists by default, with an option to load all.
+- **Testable Case**: Import tracks from a file; click "Change" next to the target playlist name; select a different playlist; verify that "Add Selected" adds the tracks to that playlist.
+
 ---
 
 ## 3. Track Management & Bulk Operations

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -27,3 +27,6 @@ Follow the coding style guidelines below when modifying or adding to the codebas
 ## UI & State Management
 - **Minimized State:** When implementing "minimize" or "collapse" functionality, use a top-level CSS class (e.g., `.minimized`) on the container. Ensure that clicking the header or a dedicated toggle button restores the state using a centralized `toggleMinimize` method.
 - **Event Delegation:** Prefer adding listeners to parent containers (like the popup header) for actions that should apply to the whole component state.
+
+## Testing & Validation
+- **Run Tests Before Commit:** Always run all automated tests (e.g., `npm test`) before making a commit to ensure no regressions are introduced.

--- a/html/in-site-popup.html
+++ b/html/in-site-popup.html
@@ -23,6 +23,7 @@
                 </div>
             </div>
             <div class="playlist-controls-wrapper">
+                <button id="cancelTargetSelectionBtn" class="btn btn-secondary hidden" aria-label="Cancel target selection" type="button">Cancel</button>
                 <button id="refreshPlaylistsBtn" class="btn btn-primary" aria-label="Load editable playlists" type="button" title="Load only your editable playlists">Load Editable Playlists</button>
                 <button id="loadAllPlaylistsBtn" class="btn btn-primary" aria-label="Load all playlists" type="button" title="Load all playlists from your library, including those you cannot edit">Load All Playlists</button>
             </div>
@@ -78,6 +79,12 @@
                         title="This action will remove the selected items from the playlist. It will not add replacements.">Remove
                         Selected</button>
                     <button id="findLocalReplacementsBtn" class="btn btn-primary hidden" type="button">Start Search</button>
+
+                    <div id="targetPlaylistContainer" class="target-playlist-container hidden">
+                        <span class="target-label">Target:</span>
+                        <span id="targetPlaylistName" class="target-name">Playlist Name</span>
+                        <button id="selectTargetPlaylistBtn" class="btn btn-primary btn-small" type="button" title="Select a different playlist to add tracks to.">Change</button>
+                    </div>
 
                     <!-- Search Container -->
                     <div class="search-container">

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite dev",
     "build": "vite build",
     "pack": "npm run build && mkdir -p dist-zip && cd dist && zip -r ../dist-zip/yt-music-plus-v$(node -p \"require('./manifest.json').version\").zip . && cd ..",
     "test": "vitest run"

--- a/scripts/bridge-ui.js
+++ b/scripts/bridge-ui.js
@@ -38,10 +38,6 @@ export class BridgeUI {
       container.replaceChildren();
     }
     document.querySelector(`.${CONSTANTS.UI.CLASSES.ITEMS_GRID_WRAPPER}`)?.classList.remove(CONSTANTS.UI.CLASSES.LIST_ONLY_MODE);
-
-    document.getElementById(CONSTANTS.UI.BUTTON_IDS.REPLACE_SELECTED)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
-    document.getElementById(CONSTANTS.UI.BUTTON_IDS.ADD_SELECTED)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
-    document.getElementById(CONSTANTS.UI.BUTTON_IDS.REMOVE_SELECTED)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
   }
 
   /**

--- a/scripts/bridge-ui.js
+++ b/scripts/bridge-ui.js
@@ -150,13 +150,62 @@ export class BridgeUI {
   }
 
   /**
+   * Toggles the visibility of the target selection UI
+   * @param {boolean} isVisible - Whether the target selection is active
+   */
+  setTargetSelectionVisibility(isVisible) {
+    const cancelBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.CANCEL_TARGET_SELECTION);
+    if (cancelBtn) cancelBtn.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !isVisible);
+
+    const detailsScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_DETAILS_SCREEN);
+    if (detailsScreen) detailsScreen.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, isVisible);
+
+    const selectionScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_SELECTION_SCREEN);
+    if (selectionScreen) selectionScreen.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !isVisible);
+
+    if (isVisible) {
+      this.updatePopupTitle(CONSTANTS.UI.STRINGS.SELECT_TARGET_TITLE);
+    }
+  }
+
+  /**
+   * Sets the list-only mode for the grid
+   * @param {boolean} isListOnly - Whether to enable list-only mode
+   */
+  setListOnlyMode(isListOnly) {
+    document.querySelector(`.${CONSTANTS.UI.CLASSES.ITEMS_GRID_WRAPPER}`)?.classList.toggle(CONSTANTS.UI.CLASSES.LIST_ONLY_MODE, isListOnly);
+  }
+
+  /**
+   * Updates the visibility of the target playlist container
+   * @param {boolean} isVisible 
+   */
+  setTargetContainerVisibility(isVisible) {
+    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !isVisible);
+  }
+
+  /**
+   * Updates visibility of bulk action buttons
+   * @param {Object} options - { replace, add, remove } visibility flags
+   */
+  updateActionButtonsVisibility(options = {}) {
+    const replaceBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.REPLACE_SELECTED);
+    const removeBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.REMOVE_SELECTED);
+    const addBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.ADD_SELECTED);
+
+    if (replaceBtn && options.replace !== undefined) replaceBtn.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !options.replace);
+    if (removeBtn && options.remove !== undefined) removeBtn.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !options.remove);
+    if (addBtn && options.add !== undefined) addBtn.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !options.add);
+  }
+
+  /**
    * Resets action buttons visibility for a newly selected playlist
    * @param {Object} playlist - The selected playlist object
    */
   resetActionButtonsForPlaylist(playlist) {
     const isEditable = playlist?.isEditable !== false;
 
-    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
+    this.setTargetContainerVisibility(false);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_LOCAL_REPLACEMENTS)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_UNAVAILABLE)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_VIDEO_TRACKS)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
@@ -164,13 +213,11 @@ export class BridgeUI {
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.IMPORT_FROM_FILE)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.LIST_ALL_TRACKS)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     
-    const replaceBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.REPLACE_SELECTED);
-    const removeBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.REMOVE_SELECTED);
-    const addBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.ADD_SELECTED);
-
-    if (replaceBtn) replaceBtn.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !isEditable);
-    if (removeBtn) removeBtn.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !isEditable);
-    if (addBtn) addBtn.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !isEditable);
+    this.updateActionButtonsVisibility({
+      replace: isEditable,
+      remove: isEditable,
+      add: isEditable
+    });
   }
 
   /**
@@ -180,7 +227,7 @@ export class BridgeUI {
   updateImportButtonVisibility(playlist) {
     const isEditable = playlist?.isEditable !== false;
 
-    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
+    this.setTargetContainerVisibility(true);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_LOCAL_REPLACEMENTS)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_UNAVAILABLE)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_VIDEO_TRACKS)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
@@ -188,13 +235,11 @@ export class BridgeUI {
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.IMPORT_FROM_FILE)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.LIST_ALL_TRACKS)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     
-    const replaceBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.REPLACE_SELECTED);
-    const removeBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.REMOVE_SELECTED);
-    const addBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.ADD_SELECTED);
-
-    if (replaceBtn) replaceBtn.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
-    if (removeBtn) removeBtn.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
-    if (addBtn) addBtn.classList.toggle(CONSTANTS.UI.CLASSES.HIDDEN, !isEditable);
+    this.updateActionButtonsVisibility({
+      replace: false,
+      remove: false,
+      add: isEditable
+    });
   }
 
   /**

--- a/scripts/bridge-ui.js
+++ b/scripts/bridge-ui.js
@@ -160,6 +160,7 @@ export class BridgeUI {
   resetActionButtonsForPlaylist(playlist) {
     const isEditable = playlist?.isEditable !== false;
 
+    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_LOCAL_REPLACEMENTS)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_UNAVAILABLE)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_VIDEO_TRACKS)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
@@ -183,6 +184,7 @@ export class BridgeUI {
   updateImportButtonVisibility(playlist) {
     const isEditable = playlist?.isEditable !== false;
 
+    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_LOCAL_REPLACEMENTS)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_UNAVAILABLE)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
     document.getElementById(CONSTANTS.UI.BUTTON_IDS.FIND_VIDEO_TRACKS)?.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
@@ -274,9 +276,33 @@ export class BridgeUI {
 
     playlistsCache.forEach((playlist) => {
       const card = PlaylistCard.render(playlist);
-      card.addEventListener('click', () => this.bridge.onPlaylistSelected(playlist));
+      card.addEventListener('click', () => {
+        if (this.bridge.isSelectingTarget) {
+          this.bridge.onTargetPlaylistSelected(playlist);
+        } else {
+          this.bridge.onPlaylistSelected(playlist);
+        }
+      });
       playlistsGrid.appendChild(card);
     });
+  }
+
+  /**
+   * Updates the target playlist display
+   * @param {Object} playlist - The target playlist
+   */
+  updateTargetPlaylistDisplay(playlist) {
+    const container = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER);
+    const nameElement = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_NAME);
+    
+    if (container && nameElement) {
+      if (playlist) {
+        nameElement.textContent = playlist.title;
+        container.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
+      } else {
+        container.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
+      }
+    }
   }
 
   /**

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -183,6 +183,8 @@ import { CONSTANTS } from '../utils/constants.js';
       this.session = new SearchSession();
       
       this.currentSelectedPlaylist = null;
+      this.targetPlaylist = null;
+      this.isSelectingTarget = false;
       this.playlistsCache = [];
       this.isReloadDisabled = false;
       this.isFetchingPlaylists = false;
@@ -419,6 +421,9 @@ import { CONSTANTS } from '../utils/constants.js';
         document.getElementById(CONSTANTS.UI.BUTTON_IDS.IMPORT_FILE_INPUT)?.click();
       });
 
+      this.attachButtonListener(CONSTANTS.UI.BUTTON_IDS.SELECT_TARGET_PLAYLIST, () => this.showPlaylistSelectionForTarget());
+      this.attachButtonListener(CONSTANTS.UI.BUTTON_IDS.CANCEL_TARGET_SELECTION, () => this.cancelTargetSelection());
+
       const fileInput = document.getElementById(CONSTANTS.UI.BUTTON_IDS.IMPORT_FILE_INPUT);
       if (fileInput) {
         fileInput.addEventListener('change', (e) => {
@@ -505,6 +510,7 @@ import { CONSTANTS } from '../utils/constants.js';
         this.ui.clearPlaylistItemsContainer();
         this.ui.clearActiveButtons();
         this.currentSelectedPlaylist = playlist;
+        this.targetPlaylist = playlist; // Default target is the selected playlist
         this.ui.setProgressText('');
       }
 
@@ -515,6 +521,7 @@ import { CONSTANTS } from '../utils/constants.js';
       if (selectionScreen) selectionScreen.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
 
       this.ui.resetActionButtonsForPlaylist(playlist);
+      this.ui.updateTargetPlaylistDisplay(this.targetPlaylist);
 
       UIHelper.toggleGrid(false);
       this.localTracks = [];
@@ -533,6 +540,63 @@ import { CONSTANTS } from '../utils/constants.js';
         this.processor.listAllTracks();
         this.ui.setActiveButton(CONSTANTS.UI.BUTTON_IDS.LIST_ALL_TRACKS);
       }
+    }
+
+    /**
+     * Shows playlist selection screen specifically for choosing a target playlist
+     */
+    async showPlaylistSelectionForTarget() {
+      this.isSelectingTarget = true;
+      
+      const cancelBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.CANCEL_TARGET_SELECTION);
+      if (cancelBtn) cancelBtn.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
+
+      const detailsScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_DETAILS_SCREEN);
+      if (detailsScreen) detailsScreen.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
+
+      const selectionScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_SELECTION_SCREEN);
+      if (selectionScreen) selectionScreen.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
+
+      this.ui.updatePopupTitle('Select Target Playlist');
+      
+      // If we only have editable playlists in cache, but user might want to see all
+      // We rely on the existing refresh/load all buttons in the selection screen.
+      // But we should ensure the current cache is displayed.
+      this.ui.displayPlaylistsForSelection(this.playlistsCache);
+    }
+
+    /**
+     * Handles target playlist selection
+     */
+    onTargetPlaylistSelected(playlist) {
+      this.targetPlaylist = playlist;
+      this.finishTargetSelection();
+    }
+
+    /**
+     * Cancels target playlist selection
+     */
+    cancelTargetSelection() {
+      this.finishTargetSelection();
+    }
+
+    /**
+     * Finishes target selection mode and returns to details screen
+     */
+    finishTargetSelection() {
+      this.isSelectingTarget = false;
+      
+      const cancelBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.CANCEL_TARGET_SELECTION);
+      if (cancelBtn) cancelBtn.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
+
+      const selectionScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_SELECTION_SCREEN);
+      if (selectionScreen) selectionScreen.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
+
+      const detailsScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_DETAILS_SCREEN);
+      if (detailsScreen) detailsScreen.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
+
+      this.ui.updateTargetPlaylistDisplay(this.targetPlaylist);
+      this.ui.updatePopupTitle(`Playlist: ${this.currentSelectedPlaylist.title}`);
     }
 
     /**
@@ -639,7 +703,8 @@ import { CONSTANTS } from '../utils/constants.js';
       this.ui.setProgressText('Adding selected items...');
 
       try {
-        const playlistId = this.currentSelectedPlaylist?.id || 
+        const playlistId = this.targetPlaylist?.id || 
+                          this.currentSelectedPlaylist?.id ||
                           this.ytMusicAPI.getCurrentPlaylistIdFromURL();
 
         if (!playlistId) return;
@@ -648,7 +713,7 @@ import { CONSTANTS } from '../utils/constants.js';
         let i = 1;
 
         for (const item of selectedItems) {
-          this.ui.setProgressText(`Adding track ${i} of ${selectedItems.length}...`);
+          this.ui.setProgressText(`Adding track ${i} of ${selectedItems.length} to ${this.targetPlaylist?.title || 'playlist'}...`);
 
           if (item.replacementMedia?.videoId) {
             try {
@@ -662,7 +727,7 @@ import { CONSTANTS } from '../utils/constants.js';
         }
 
         const countAdded = selectedItems.filter(item => item.replacementMedia?.videoId).length;
-        this.ui.setProgressText(countAdded > 0 ? `All additions completed. Added ${countAdded} items.` : 'No valid items were added.');
+        this.ui.setProgressText(countAdded > 0 ? `All additions completed. Added ${countAdded} items to ${this.targetPlaylist?.title || 'playlist'}.` : 'No valid items were added.');
       } catch (error) {
         this.ui.setProgressText('Error occurred while adding items.');
       } finally {

--- a/scripts/bridge.js
+++ b/scripts/bridge.js
@@ -547,17 +547,7 @@ import { CONSTANTS } from '../utils/constants.js';
      */
     async showPlaylistSelectionForTarget() {
       this.isSelectingTarget = true;
-      
-      const cancelBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.CANCEL_TARGET_SELECTION);
-      if (cancelBtn) cancelBtn.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
-
-      const detailsScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_DETAILS_SCREEN);
-      if (detailsScreen) detailsScreen.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
-
-      const selectionScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_SELECTION_SCREEN);
-      if (selectionScreen) selectionScreen.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
-
-      this.ui.updatePopupTitle('Select Target Playlist');
+      this.ui.setTargetSelectionVisibility(true);
       
       // If we only have editable playlists in cache, but user might want to see all
       // We rely on the existing refresh/load all buttons in the selection screen.
@@ -585,16 +575,7 @@ import { CONSTANTS } from '../utils/constants.js';
      */
     finishTargetSelection() {
       this.isSelectingTarget = false;
-      
-      const cancelBtn = document.getElementById(CONSTANTS.UI.BUTTON_IDS.CANCEL_TARGET_SELECTION);
-      if (cancelBtn) cancelBtn.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
-
-      const selectionScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_SELECTION_SCREEN);
-      if (selectionScreen) selectionScreen.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
-
-      const detailsScreen = document.getElementById(CONSTANTS.UI.ELEMENT_IDS.PLAYLIST_DETAILS_SCREEN);
-      if (detailsScreen) detailsScreen.classList.remove(CONSTANTS.UI.CLASSES.HIDDEN);
-
+      this.ui.setTargetSelectionVisibility(false);
       this.ui.updateTargetPlaylistDisplay(this.targetPlaylist);
       this.ui.updatePopupTitle(`Playlist: ${this.currentSelectedPlaylist.title}`);
     }
@@ -711,9 +692,10 @@ import { CONSTANTS } from '../utils/constants.js';
 
         const selectedItems = UIHelper.getSelectedMediaItems();
         let i = 1;
+        const targetTitle = this.targetPlaylist?.title || this.currentSelectedPlaylist?.title || CONSTANTS.UI.STRINGS.PLAYLIST_FALLBACK;
 
         for (const item of selectedItems) {
-          this.ui.setProgressText(`Adding track ${i} of ${selectedItems.length} to ${this.targetPlaylist?.title || 'playlist'}...`);
+          this.ui.setProgressText(`${CONSTANTS.UI.STRINGS.IMPORT_ADD_PROGRESS_PREFIX} ${i} of ${selectedItems.length} to ${targetTitle}...`);
 
           if (item.replacementMedia?.videoId) {
             try {
@@ -727,7 +709,7 @@ import { CONSTANTS } from '../utils/constants.js';
         }
 
         const countAdded = selectedItems.filter(item => item.replacementMedia?.videoId).length;
-        this.ui.setProgressText(countAdded > 0 ? `All additions completed. Added ${countAdded} items to ${this.targetPlaylist?.title || 'playlist'}.` : 'No valid items were added.');
+        this.ui.setProgressText(countAdded > 0 ? `${CONSTANTS.UI.STRINGS.IMPORT_ADD_COMPLETED} Added ${countAdded} items to ${targetTitle}.` : 'No valid items were added.');
       } catch (error) {
         this.ui.setProgressText('Error occurred while adding items.');
       } finally {

--- a/scripts/track-processor.js
+++ b/scripts/track-processor.js
@@ -134,7 +134,7 @@ export class TrackProcessor {
     this.bridge.session.isCancelled = false;
     this.bridge.ui.clearPlaylistItemsContainer();
     this.bridge.ui.resetActionButtonsForPlaylist(this.bridge.currentSelectedPlaylist);
-    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
+    this.bridge.ui.setTargetContainerVisibility(false);
     this.bridge.ui.toggleSearchProgress(true, true);
     this.bridge.ui.setProgressText('Finding unavailable tracks...');
 
@@ -167,7 +167,7 @@ export class TrackProcessor {
     this.bridge.session.isCancelled = false;
     this.bridge.ui.clearPlaylistItemsContainer();
     this.bridge.ui.resetActionButtonsForPlaylist(this.bridge.currentSelectedPlaylist);
-    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
+    this.bridge.ui.setTargetContainerVisibility(false);
     this.bridge.ui.toggleSearchProgress(true, true);
     this.bridge.ui.setProgressText('Finding video tracks...');
 
@@ -262,8 +262,8 @@ export class TrackProcessor {
   async listAllTracks() {
     this.bridge.session.isCancelled = false;
     this.bridge.ui.clearPlaylistItemsContainer();
-    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
-    document.querySelector('.items-grid-wrapper')?.classList.add('list-only-mode');
+    this.bridge.ui.setTargetContainerVisibility(false);
+    this.bridge.ui.setListOnlyMode(true);
     this.bridge.ui.toggleSearchProgress(true, true);
     this.bridge.ui.setProgressText('Fetching all tracks...');
 
@@ -292,9 +292,11 @@ export class TrackProcessor {
         this.bridge.ui.addItem(track, CONSTANTS.API.BASE_URL, i++);
       }
 
-      document.getElementById('replaceSelectedBtn')?.classList.add('hidden');
-      document.getElementById('addSelectedBtn')?.classList.add('hidden');
-      document.getElementById('removeSelectedBtn')?.classList.remove('hidden');
+      this.bridge.ui.updateActionButtonsVisibility({
+        replace: false,
+        add: false,
+        remove: true
+      });
 
       UIHelper.updateCheckAllCheckbox();
     } catch (error) {

--- a/scripts/track-processor.js
+++ b/scripts/track-processor.js
@@ -133,6 +133,7 @@ export class TrackProcessor {
   async findUnavailableTracks() {
     this.bridge.session.isCancelled = false;
     this.bridge.ui.clearPlaylistItemsContainer();
+    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
     this.bridge.ui.toggleSearchProgress(true, true);
     this.bridge.ui.setProgressText('Finding unavailable tracks...');
 
@@ -164,6 +165,7 @@ export class TrackProcessor {
   async findVideoTracks() {
     this.bridge.session.isCancelled = false;
     this.bridge.ui.clearPlaylistItemsContainer();
+    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
     this.bridge.ui.toggleSearchProgress(true, true);
     this.bridge.ui.setProgressText('Finding video tracks...');
 
@@ -258,6 +260,7 @@ export class TrackProcessor {
   async listAllTracks() {
     this.bridge.session.isCancelled = false;
     this.bridge.ui.clearPlaylistItemsContainer();
+    document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
     document.querySelector('.items-grid-wrapper')?.classList.add('list-only-mode');
     this.bridge.ui.toggleSearchProgress(true, true);
     this.bridge.ui.setProgressText('Fetching all tracks...');

--- a/scripts/track-processor.js
+++ b/scripts/track-processor.js
@@ -133,6 +133,7 @@ export class TrackProcessor {
   async findUnavailableTracks() {
     this.bridge.session.isCancelled = false;
     this.bridge.ui.clearPlaylistItemsContainer();
+    this.bridge.ui.resetActionButtonsForPlaylist(this.bridge.currentSelectedPlaylist);
     document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
     this.bridge.ui.toggleSearchProgress(true, true);
     this.bridge.ui.setProgressText('Finding unavailable tracks...');
@@ -165,6 +166,7 @@ export class TrackProcessor {
   async findVideoTracks() {
     this.bridge.session.isCancelled = false;
     this.bridge.ui.clearPlaylistItemsContainer();
+    this.bridge.ui.resetActionButtonsForPlaylist(this.bridge.currentSelectedPlaylist);
     document.getElementById(CONSTANTS.UI.ELEMENT_IDS.TARGET_PLAYLIST_CONTAINER)?.classList.add(CONSTANTS.UI.CLASSES.HIDDEN);
     this.bridge.ui.toggleSearchProgress(true, true);
     this.bridge.ui.setProgressText('Finding video tracks...');

--- a/styles/in-site-popup.css
+++ b/styles/in-site-popup.css
@@ -895,8 +895,8 @@
     position: relative;
     margin-left: auto;
     flex: 1;
-    max-width: 300px;
-    min-width: 200px;
+    max-width: 200px;
+    min-width: 150px;
 }
 
 .search-input {
@@ -1034,4 +1034,38 @@
 .yt-music-plus-control-btn.btn-seek-forward {
     font-size: 18px;
     color: #030303; /* Consistent color theme */
+}
+/* Target Playlist Section */
+.target-playlist-container {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: #444;
+    padding: 6px 16px;
+    background-color: transparent;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin-top: 0;
+    width: fit-content;
+}
+
+.target-label {
+    font-weight: 600;
+    color: #666;
+}
+
+.target-name {
+    font-weight: 500;
+    color: #1976d2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 150px;
+}
+
+.btn-small {
+    padding: 4px 10px;
+    font-size: 11px;
+    border-radius: 4px;
 }

--- a/tests/scripts/bridge-ui.test.js
+++ b/tests/scripts/bridge-ui.test.js
@@ -74,24 +74,15 @@ describe('BridgeUI', () => {
   });
 
   describe('clearPlaylistItemsContainer', () => {
-    it('should clear rows and ensure action buttons are visible', () => {
+    it('should clear rows and rowMap', () => {
       const container = document.getElementById('yt-music-plus-itemsGridContainer');
       container.appendChild(document.createElement('div'));
       
-      const replaceBtn = document.getElementById('replaceSelectedBtn');
-      const addBtn = document.getElementById('addSelectedBtn');
-      const removeBtn = document.getElementById('removeSelectedBtn');
-      
-      replaceBtn.classList.add('hidden');
-      addBtn.classList.add('hidden');
-      removeBtn.classList.add('hidden');
+      bridgeUI.rowMap.set(0, {});
 
       bridgeUI.clearPlaylistItemsContainer();
 
       expect(container.children.length).toBe(0);
-      expect(replaceBtn.classList.contains('hidden')).toBe(false);
-      expect(addBtn.classList.contains('hidden')).toBe(false);
-      expect(removeBtn.classList.contains('hidden')).toBe(false);
       expect(bridgeUI.rowMap.size).toBe(0);
     });
   });

--- a/tests/scripts/bridge-ui.test.js
+++ b/tests/scripts/bridge-ui.test.js
@@ -307,15 +307,39 @@ describe('BridgeUI', () => {
       expect(replaceBtn.classList.contains('hidden')).toBe(true);
     });
 
-    it('should hide Replace and Remove buttons in import mode', () => {
+    it('should hide Replace and Remove buttons in import mode and show target playlist container', () => {
       const playlist = { isEditable: true };
       const replaceBtn = document.getElementById('replaceSelectedBtn');
       const removeBtn = document.getElementById('removeSelectedBtn');
+      const targetContainer = document.getElementById('targetPlaylistContainer');
       
       bridgeUI.updateImportButtonVisibility(playlist);
       
       expect(replaceBtn.classList.contains('hidden')).toBe(true);
       expect(removeBtn.classList.contains('hidden')).toBe(true);
+      expect(targetContainer.classList.contains('hidden')).toBe(false);
+    });
+  });
+
+  describe('updateTargetPlaylistDisplay', () => {
+    it('should show container and set name when playlist is provided', () => {
+      const playlist = { title: 'My Target Playlist' };
+      const container = document.getElementById('targetPlaylistContainer');
+      const nameEl = document.getElementById('targetPlaylistName');
+      
+      bridgeUI.updateTargetPlaylistDisplay(playlist);
+      
+      expect(container.classList.contains('hidden')).toBe(false);
+      expect(nameEl.textContent).toBe('My Target Playlist');
+    });
+
+    it('should hide container when playlist is null', () => {
+      const container = document.getElementById('targetPlaylistContainer');
+      container.classList.remove('hidden');
+      
+      bridgeUI.updateTargetPlaylistDisplay(null);
+      
+      expect(container.classList.contains('hidden')).toBe(true);
     });
   });
 });

--- a/tests/scripts/ui-visibility-integration.test.js
+++ b/tests/scripts/ui-visibility-integration.test.js
@@ -20,7 +20,11 @@ describe('UI Visibility Integration', () => {
         isAuthTokenSet: vi.fn(() => true)
       },
       _createMediaObjects: vi.fn((item) => ({ originalMedia: item, replacementMedia: {} })),
-      playerHandler: {},
+      playerHandler: {
+        isLocalFilePlaying: vi.fn(() => false),
+        getVideoData: vi.fn(() => null),
+        getPlayerState: vi.fn(() => -1) // CONSTANTS.PLAYER.STATE.UNSTARTED
+      },
       session: { isCancelled: false },
       currentSelectedPlaylist: { id: 'p123', isEditable: true }
     };
@@ -48,6 +52,70 @@ describe('UI Visibility Integration', () => {
       expect(replaceBtn.classList.contains('hidden')).toBe(true);
       expect(addBtn.classList.contains('hidden')).toBe(true);
       expect(removeBtn.classList.contains('hidden')).toBe(false);
+    });
+  });
+
+  describe('Target Playlist Visibility', () => {
+    it('should hide target playlist container when listing all tracks', async () => {
+      const targetContainer = document.getElementById('targetPlaylistContainer');
+      targetContainer.classList.remove('hidden');
+      
+      mockBridge.ytMusicAPI.getPlaylistItems.mockResolvedValue([]);
+      await trackProcessor.listAllTracks();
+      
+      expect(targetContainer.classList.contains('hidden')).toBe(true);
+    });
+
+    it('should hide target playlist container when finding unavailable tracks', async () => {
+      const targetContainer = document.getElementById('targetPlaylistContainer');
+      targetContainer.classList.remove('hidden');
+      
+      mockBridge.ytMusicAPI.getPlaylistItems.mockResolvedValue([]);
+      await trackProcessor.findUnavailableTracks();
+      
+      expect(targetContainer.classList.contains('hidden')).toBe(true);
+    });
+  });
+
+  describe('Target Playlist Selection', () => {
+    it('should toggle screens correctly during target selection', () => {
+      const detailsScreen = document.getElementById('playlistDetailsScreen');
+      const selectionScreen = document.getElementById('playlistSelectionScreen');
+      const cancelBtn = document.getElementById('cancelTargetSelectionBtn');
+      const popupTitle = document.getElementById('popupTitle');
+
+      // Mock the methods on bridge
+      mockBridge.targetPlaylist = { id: 'p1', title: 'P1' };
+      mockBridge.currentSelectedPlaylist = { id: 'p1', title: 'P1' };
+      mockBridge.playlistsCache = [{ id: 'p1', title: 'P1' }, { id: 'p2', title: 'P2' }];
+      
+      // Simulate showPlaylistSelectionForTarget
+      mockBridge.isSelectingTarget = true;
+      cancelBtn.classList.remove('hidden');
+      detailsScreen.classList.add('hidden');
+      selectionScreen.classList.remove('hidden');
+      popupTitle.textContent = 'Select Target Playlist';
+      bridgeUI.displayPlaylistsForSelection(mockBridge.playlistsCache);
+
+      expect(detailsScreen.classList.contains('hidden')).toBe(true);
+      expect(selectionScreen.classList.contains('hidden')).toBe(false);
+      expect(cancelBtn.classList.contains('hidden')).toBe(false);
+      expect(popupTitle.textContent).toBe('Select Target Playlist');
+
+      // Simulate onTargetPlaylistSelected
+      const newTarget = { id: 'p2', title: 'P2' };
+      mockBridge.targetPlaylist = newTarget;
+      mockBridge.isSelectingTarget = false;
+      cancelBtn.classList.add('hidden');
+      selectionScreen.classList.add('hidden');
+      detailsScreen.classList.remove('hidden');
+      bridgeUI.updateTargetPlaylistDisplay(newTarget);
+      popupTitle.textContent = 'Playlist: P1';
+
+      expect(detailsScreen.classList.contains('hidden')).toBe(false);
+      expect(selectionScreen.classList.contains('hidden')).toBe(true);
+      expect(cancelBtn.classList.contains('hidden')).toBe(true);
+      expect(document.getElementById('targetPlaylistName').textContent).toBe('P2');
     });
   });
 });

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -45,7 +45,9 @@ export const CONSTANTS = {
       REFRESH_PLAYLISTS: 'refreshPlaylistsBtn',
       LOAD_ALL_PLAYLISTS: 'loadAllPlaylistsBtn',
       CLOSE_POPUP: 'closePopupBtn',
-      MINIMIZE_POPUP: 'minimizePopupBtn'
+      MINIMIZE_POPUP: 'minimizePopupBtn',
+      SELECT_TARGET_PLAYLIST: 'selectTargetPlaylistBtn',
+      CANCEL_TARGET_SELECTION: 'cancelTargetSelectionBtn'
     },
     ELEMENT_IDS: {
       PROGRESS_TEXT: 'progressText',
@@ -63,6 +65,8 @@ export const CONSTANTS = {
       PLAYLIST_DETAILS_SCREEN: 'playlistDetailsScreen',
       PLAYLIST_SELECTION_SCREEN: 'playlistSelectionScreen',
       MAIN_POPUP: 'yt-music-plus-mainPopup',
+      TARGET_PLAYLIST_NAME: 'targetPlaylistName',
+      TARGET_PLAYLIST_CONTAINER: 'targetPlaylistContainer',
     },
     CLASSES: {
       ACTIVE: 'active',

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -88,6 +88,12 @@ export const CONSTANTS = {
       YT_MUSIC_HEADER: 'ytmusic-responsive-header-renderer',
       ITEMS_GRID_CHECKBOXES: '#yt-music-plus-itemsGridContainer .item-checkbox',
       ACTIVE_ACTION_BUTTON: '.playlist-action-buttons .btn.active',
+    },
+    STRINGS: {
+      SELECT_TARGET_TITLE: 'Select Target Playlist',
+      PLAYLIST_FALLBACK: 'playlist',
+      IMPORT_ADD_PROGRESS_PREFIX: 'Adding track',
+      IMPORT_ADD_COMPLETED: 'All additions completed.',
     }
   },
   SETTINGS: {


### PR DESCRIPTION
This PR introduces the ability to select a target playlist when importing tracks from local folders or text files.

Key changes:
- New 'Change' button in the import view to select a different target playlist.
- Target selection grid that respects user settings (editable vs all playlists).
- 'Cancel' option during target selection to return to the previous view.
- UI improvements to integrate the selection box into the action bar.
- Updated 'Add Selected' logic to target the chosen playlist.
- Added comprehensive unit and integration tests.
- Updated GEMINI.md with test-before-commit mandate.