### PR TITLE
feat: allow all operations on any playlist

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -49,7 +49,8 @@ This document provides a comprehensive list of features for the YouTube Music + 
     - **Load All Playlists**: Fetches all playlists found in the user's library, including liked playlists and albums added as playlists.
 - **Auto-Listing**: By default, selecting a playlist from the grid will automatically fetch and display all its tracks if no other button is active. This behavior can be toggled in Settings.
 - **Default Behavior**: Defaults to editable playlists unless "Always load all playlists" is enabled in settings.
-- **Testable Case**: Click "Load Editable Playlists" and verify only owned/editable playlists appear; click "Load All Playlists" and verify a broader set of playlists is loaded.
+- **Playlist Editability**: All loaded playlists are treated as editable, allowing all operations (Replace, Add, Remove, etc.) on any selected playlist. The "editable" count in the UI serves as an indicator of YouTube Music's reported status, but does not restrict extension functionality.
+- **Testable Case**: Click "Load Editable Playlists" and verify only owned/editable playlists appear; click "Load All Playlists" and verify a broader set of playlists is loaded. Ensure action buttons (e.g., "Remove Selected") are visible and functional even for playlists marked as non-editable.
 
 ### 2.2 Find Unavailable Tracks
 - **Feature**: Scans the selected playlist for "greyed-out" (unavailable) tracks.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The core functionality is cleaning up playlists. Here's how it works:
 2.  **Open the Extension:** Click on the "YouTube Music +" button that appears in the header or in the navigation bar. It may take a couple of seconds for the buttons to show up as the extension initializes.
 
     ![Screenshot of opening the extension](/images/1.%20Extension%20buttons.png)
-3. **Select a playlist:** From the list of playlists that you have access to edit, choose one. If you are already on a playlist page, it will be auto-selected.
+3. **Select a playlist:** Choose one from your library. The extension fetches your editable playlists by default, but you can also load all playlists (including albums and liked playlists) using the buttons in the footer or by changing the extension settings. **All loaded playlists can be managed using the extension's tools, even if they are marked as non-editable.**
     ![Screenshot of selecting a playlist](/images/2.%20Editable%20playlists.png)
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Music +",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "action": {
     "default_popup": "popup/popup.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-music-plus",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "type": "module",
   "scripts": {

--- a/scripts/bridge-ui.js
+++ b/scripts/bridge-ui.js
@@ -362,7 +362,8 @@ export class BridgeUI {
    * @param {Object} playlist - The currently selected playlist
    */
   updateViewMode(mode, playlist) {
-    const isEditable = playlist?.isEditable !== false;
+    // Always allow operations as if editable, even if YouTube Music reports otherwise
+    const isEditable = true;
     const { VIEW_MODES, BUTTON_IDS, ELEMENT_IDS, CLASSES } = CONSTANTS.UI;
 
     // 1. Reset specific UI states

--- a/tests/scripts/bridge-ui-coverage.test.js
+++ b/tests/scripts/bridge-ui-coverage.test.js
@@ -214,9 +214,9 @@ describe('BridgeUI Coverage', () => {
       expect(document.getElementById(CONSTANTS.UI.ELEMENT_IDS.GRID_HEADER_REPLACEMENT).textContent).toBe('Ignore Group');
     });
 
-    it('should hide editable actions if playlist is not editable', () => {
+    it('should show editable actions even if playlist is not editable', () => {
       bridgeUI.updateViewMode(CONSTANTS.UI.VIEW_MODES.SEARCH_RESULTS, { isEditable: false });
-      expect(document.getElementById(CONSTANTS.UI.BUTTON_IDS.REPLACE_SELECTED).classList.contains(CONSTANTS.UI.CLASSES.HIDDEN)).toBe(true);
+      expect(document.getElementById(CONSTANTS.UI.BUTTON_IDS.REPLACE_SELECTED).classList.contains(CONSTANTS.UI.CLASSES.HIDDEN)).toBe(false);
     });
   });
 


### PR DESCRIPTION
Even if playlists are not explicitly marked as editable by YouTube Music, all operations (Replace, Add, Remove, etc.) are now allowed. This addresses issues where the extension cannot reliably identify editability status. The 'editable' count in the UI is preserved for user information.