### PR TITLE
fix: resolve track playback from popup and synchronize player bar metadata (v1.9.0)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -140,6 +140,8 @@ This document provides a comprehensive list of features for the YouTube Music + 
 - **Feature**: Playback controls (Play, Pause, Skip forward/backward 10s) integrated into the media grid.
 - **Behavior**: Controls appear as an overlay when hovering over the track details section (Original or Replacement media).
 - **Control**: Allows users to preview tracks directly within the popup without navigating away from the current workspace.
+- **Resilient Player API**: Uses candidate fallback resolution (`ytmusic-app.playerApi`, `#movie_player`, `ytmusic-player-bar`) with safe object/string parameter handling for `loadVideoById`, `video_id`/`videoId` metadata matching, and `seekTo` fallback when `seekBy` is unavailable.
+- **Player Bar Synchronization**: Automatically updates YouTube Music's bottom player bar (`ytmusic-player-bar`) thumbnail, track title, and artist name immediately upon track playback, both for YouTube tracks and local audio files.
 - **Enhanced Player API**: Exposed methods for advanced player control including `getVideoData`, `getPlayerState`, `nextTrack`, `previousTrack`, `getVolume`, `setVolume`, `isMuted`, `mute`, `unMute`, `getCurrentTime`, and `getDuration`.
 - **Testable Case**: Hover over a track title in the grid; verify playback controls appear and function as expected (controlling the page's background player).
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "YouTube Music +",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "action": {
     "default_popup": "popup/popup.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yt-music-plus",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Chrome extension for YouTube Music with utilities to remove unavailable tracks, find replacements, and more.",
   "type": "module",
   "scripts": {

--- a/scripts/player-handler.js
+++ b/scripts/player-handler.js
@@ -18,9 +18,27 @@ export class PlayerHandler {
    * Centralized getter for the player API
    * @returns {Object|null}
    */
+  /**
+   * Centralized getter for the player API
+   * @returns {Object|null}
+   */
   get api() {
     const app = document.querySelector('ytmusic-app');
-    return app?.playerApi || null;
+    if (app?.playerApi && typeof app.playerApi.loadVideoById === 'function') {
+      return app.playerApi;
+    }
+    const moviePlayer = document.getElementById('movie_player');
+    if (moviePlayer && typeof moviePlayer.loadVideoById === 'function') {
+      return moviePlayer;
+    }
+    const playerBar = document.querySelector('ytmusic-player-bar');
+    if (playerBar?.playerApi && typeof playerBar.playerApi.loadVideoById === 'function') {
+      return playerBar.playerApi;
+    }
+    if (playerBar && typeof playerBar.loadVideoById === 'function') {
+      return playerBar;
+    }
+    return app?.playerApi || moviePlayer || null;
   }
 
   /**
@@ -46,28 +64,51 @@ export class PlayerHandler {
   /**
    * Playback actions
    */
-  playTrack(videoId) {
+  playTrack(videoId, trackInfo = null) {
+    if (!videoId) return;
+
     // Stop local player if running
     this.pauseLocalTrack();
     this.activeSource = CONSTANTS.PLAYER.SOURCE.YOUTUBE;
 
     const playerApi = this.api;
-    if (!playerApi) return;
-    
-    // Check if it's already the current video
-    const currentVideoId = playerApi.getVideoData()?.video_id;
-    if (currentVideoId === videoId) {
-      playerApi.playVideo();
-    } else {
-      playerApi.loadVideoById(videoId);
+    if (playerApi) {
+      // Check if it's already the current video
+      const currentVideoData = playerApi.getVideoData?.();
+      const currentVideoId = currentVideoData?.video_id || currentVideoData?.videoId;
+      if (currentVideoId === videoId) {
+        if (typeof playerApi.playVideo === 'function') {
+          playerApi.playVideo();
+        }
+      } else {
+        if (typeof playerApi.loadVideoById === 'function') {
+          try {
+            playerApi.loadVideoById(videoId);
+          } catch (error) {
+            try {
+              playerApi.loadVideoById({ videoId });
+            } catch (innerError) {
+              console.error('PlayerHandler: Failed to load video by ID', innerError);
+            }
+          }
+        }
+      }
     }
+
+    // Immediately update player bar elements (thumbnail, title, artist)
+    this.updatePlayerBar(videoId, trackInfo);
+
+    // Schedule a delayed update to catch metadata returned by YouTube API after video loads
+    setTimeout(() => {
+      this.updatePlayerBar(videoId, trackInfo);
+    }, CONSTANTS.UI.UI_UPDATE_DELAY_MS);
   }
 
   playLocalFile(file) {
     if (!file) return;
 
     // Pause YouTube player
-    this.api?.pauseVideo();
+    this.pauseTrack();
     this.activeSource = CONSTANTS.PLAYER.SOURCE.LOCAL;
 
     if (!this.localPlayer) {
@@ -91,10 +132,126 @@ export class PlayerHandler {
       console.error('PlayerHandler: Local playback failed', error);
       this.activeSource = CONSTANTS.PLAYER.SOURCE.YOUTUBE;
     });
+
+    this.updatePlayerBar(null, { name: file.name, artist: 'Local Audio File' });
+  }
+
+  /**
+   * Ensures the bottom player bar is visible if it was hidden
+   */
+  showPlayerBar() {
+    const playerBar = document.querySelector('ytmusic-player-bar');
+    if (!playerBar) return;
+
+    playerBar.removeAttribute('hidden');
+    playerBar.hidden = false;
+    playerBar.classList.remove('hidden', 'yt-music-plus-hidden');
+
+    if (playerBar.style.display === 'none') {
+      playerBar.style.display = '';
+    }
+    if (playerBar.style.visibility === 'hidden') {
+      playerBar.style.visibility = 'visible';
+    }
+
+    let parent = playerBar.parentElement;
+    while (parent && parent.tagName !== 'BODY') {
+      if (parent.hasAttribute('hidden')) {
+        parent.removeAttribute('hidden');
+      }
+      if (parent.hidden) {
+        parent.hidden = false;
+      }
+      if (parent.classList.contains('hidden')) {
+        parent.classList.remove('hidden');
+      }
+      if (parent.style.display === 'none') {
+        parent.style.display = '';
+      }
+      parent = parent.parentElement;
+    }
+  }
+
+  /**
+   * Updates the YouTube Music bottom player bar (ytmusic-player-bar) thumbnail, title, and artist
+   * @param {string|null} videoId 
+   * @param {Object|null} [trackInfo=null] 
+   */
+  updatePlayerBar(videoId, trackInfo = null) {
+    const playerBar = document.querySelector('ytmusic-player-bar');
+    if (!playerBar) return;
+
+    this.showPlayerBar();
+
+    // Retrieve video data from API if trackInfo is missing or incomplete
+    const videoData = this.getVideoData() || {};
+    const titleText = trackInfo?.name || trackInfo?.title || videoData.title;
+    const artistText = trackInfo?.artist || videoData.author;
+    const thumbnailUrl = trackInfo?.thumbnail || (videoId ? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg` : null);
+
+    // 1. Update Thumbnail
+    if (thumbnailUrl) {
+      const thumbImgs = playerBar.querySelectorAll('.thumbnail-image-wrapper img, #thumbnail img, img.image, .image, img#img');
+      thumbImgs.forEach(img => {
+        if (img.src !== thumbnailUrl) {
+          img.src = thumbnailUrl;
+        }
+      });
+    }
+
+    // 2. Update Title
+    if (titleText) {
+      const titleEls = playerBar.querySelectorAll('.title, yt-formatted-string.title, .content-info-wrapper .title');
+      titleEls.forEach(titleEl => {
+        const childLink = titleEl.querySelector('a');
+        if (childLink) {
+          childLink.textContent = titleText;
+          childLink.title = titleText;
+          if (videoId) {
+            childLink.href = `watch?v=${videoId}`;
+          }
+        } else {
+          titleEl.textContent = titleText;
+        }
+        titleEl.title = titleText;
+      });
+    }
+
+    // 3. Update Artist / Byline
+    if (artistText) {
+      const bylineEls = playerBar.querySelectorAll('.byline, yt-formatted-string.byline, .content-info-wrapper .byline');
+      bylineEls.forEach(bylineEl => {
+        const childLink = bylineEl.querySelector('a');
+        if (childLink) {
+          childLink.textContent = artistText;
+          childLink.title = artistText;
+        } else {
+          bylineEl.textContent = artistText;
+        }
+        bylineEl.title = artistText;
+      });
+    }
+
+    // 4. Update Polymer / Custom Element properties if present
+    try {
+      if ('currentVideoData' in playerBar || 'videoData' in playerBar) {
+        const dataObj = {
+          title: titleText,
+          author: artistText,
+          videoId: videoId
+        };
+        if (playerBar.currentVideoData) Object.assign(playerBar.currentVideoData, dataObj);
+        if (playerBar.videoData) Object.assign(playerBar.videoData, dataObj);
+      }
+    } catch (e) {
+      // Ignore polymer mutation errors silently
+    }
   }
 
   pauseTrack() {
-    this.api?.pauseVideo();
+    if (typeof this.api?.pauseVideo === 'function') {
+      this.api.pauseVideo();
+    }
     this.pauseLocalTrack();
   }
 
@@ -108,7 +265,14 @@ export class PlayerHandler {
     if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
       this.localPlayer.currentTime += seconds;
     } else {
-      this.api?.seekBy(seconds);
+      const api = this.api;
+      if (!api) return;
+      if (typeof api.seekBy === 'function') {
+        api.seekBy(seconds);
+      } else if (typeof api.seekTo === 'function' && typeof api.getCurrentTime === 'function') {
+        const currentTime = api.getCurrentTime() || 0;
+        api.seekTo(currentTime + seconds, true);
+      }
     }
   }
 
@@ -116,60 +280,70 @@ export class PlayerHandler {
    * Additional player methods
    */
   getVideoData() {
-    return this.api?.getVideoData() || null;
+    return this.api?.getVideoData?.() || null;
   }
 
   nextTrack() {
-    this.api?.nextVideo();
+    if (typeof this.api?.nextVideo === 'function') {
+      this.api.nextVideo();
+    }
   }
 
   previousTrack() {
-    this.api?.previousVideo();
+    if (typeof this.api?.previousVideo === 'function') {
+      this.api.previousVideo();
+    }
   }
 
   getVolume() {
     if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
       return this.localPlayer.volume * 100;
     }
-    return this.api?.getVolume() || 0;
+    return this.api?.getVolume?.() || 0;
   }
 
   setVolume(volume) {
     if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
       this.localPlayer.volume = volume / 100;
     }
-    this.api?.setVolume(volume);
+    if (typeof this.api?.setVolume === 'function') {
+      this.api.setVolume(volume);
+    }
   }
 
   isMuted() {
     if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
       return this.localPlayer.muted;
     }
-    return this.api?.isMuted() || false;
+    return this.api?.isMuted?.() || false;
   }
 
   mute() {
     if (this.localPlayer) this.localPlayer.muted = true;
-    this.api?.mute();
+    if (typeof this.api?.mute === 'function') {
+      this.api.mute();
+    }
   }
 
   unMute() {
     if (this.localPlayer) this.localPlayer.muted = false;
-    this.api?.unMute();
+    if (typeof this.api?.unMute === 'function') {
+      this.api.unMute();
+    }
   }
 
   getCurrentTime() {
     if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
       return this.localPlayer.currentTime;
     }
-    return this.api?.getCurrentTime() || 0;
+    return this.api?.getCurrentTime?.() || 0;
   }
 
   getDuration() {
     if (this.activeSource === CONSTANTS.PLAYER.SOURCE.LOCAL && this.localPlayer) {
       return this.localPlayer.duration || 0;
     }
-    return this.api?.getDuration() || 0;
+    return this.api?.getDuration?.() || 0;
   }
 
   /**
@@ -181,7 +355,7 @@ export class PlayerHandler {
       if (this.localPlayer.ended) return CONSTANTS.PLAYER.STATE.ENDED;
       return this.localPlayer.paused ? CONSTANTS.PLAYER.STATE.PAUSED : CONSTANTS.PLAYER.STATE.PLAYING;
     }
-    return this.api?.getPlayerState() ?? CONSTANTS.PLAYER.STATE.UNSTARTED;
+    return this.api?.getPlayerState?.() ?? CONSTANTS.PLAYER.STATE.UNSTARTED;
   }
 
   /**

--- a/tests/scripts/bridge.test.js
+++ b/tests/scripts/bridge.test.js
@@ -381,14 +381,14 @@ describe('Bridge Script Unit Tests', () => {
         data: {
           type: CONSTANTS.MESSAGE_TYPES.EXT_SETTINGS,
           settings: { showPlaylistButton: false },
-          version: '1.8.0'
+          version: '1.9.0'
         },
         source: window
       });
       window.dispatchEvent(event);
       
       expect(bridge.extSettings).toEqual({ showPlaylistButton: false });
-      expect(bridge.version).toBe('1.8.0');
+      expect(bridge.version).toBe('1.9.0');
     });
   });
 

--- a/tests/scripts/player-handler.test.js
+++ b/tests/scripts/player-handler.test.js
@@ -18,7 +18,7 @@ describe('PlayerHandler', () => {
   });
 
   it('should initialize successfully when playerApi is available', () => {
-    const mockApi = { playVideo: vi.fn() };
+    const mockApi = { loadVideoById: vi.fn(), playVideo: vi.fn() };
     const mockApp = document.createElement('ytmusic-app');
     mockApp.playerApi = mockApi;
     document.body.appendChild(mockApp);
@@ -28,13 +28,31 @@ describe('PlayerHandler', () => {
     expect(handler.api).toBe(mockApi);
   });
 
+  it('should find movie_player when ytmusic-app has no playerApi', () => {
+    const moviePlayer = document.createElement('div');
+    moviePlayer.id = 'movie_player';
+    moviePlayer.loadVideoById = vi.fn();
+    document.body.appendChild(moviePlayer);
+
+    expect(handler.api).toBe(moviePlayer);
+  });
+
+  it('should find ytmusic-player-bar when ytmusic-app and movie_player are absent', () => {
+    const playerBar = document.createElement('ytmusic-player-bar');
+    const mockApi = { loadVideoById: vi.fn() };
+    playerBar.playerApi = mockApi;
+    document.body.appendChild(playerBar);
+
+    expect(handler.api).toBe(mockApi);
+  });
+
   it('should retry initialization if playerApi is not immediately available', () => {
     handler.init();
     expect(handler.initialized).toBe(false);
     expect(handler.retryCount).toBe(1);
 
     // Add mock app after first try
-    const mockApi = { playVideo: vi.fn() };
+    const mockApi = { loadVideoById: vi.fn(), playVideo: vi.fn() };
     const mockApp = document.createElement('ytmusic-app');
     mockApp.playerApi = mockApi;
     document.body.appendChild(mockApp);
@@ -59,9 +77,24 @@ describe('PlayerHandler', () => {
 
   it('should call playVideo when playTrack is called with current videoId', () => {
     const mockApi = { 
+      loadVideoById: vi.fn(),
       getVideoData: vi.fn().mockReturnValue({ video_id: 'vid123' }),
-      playVideo: vi.fn(),
-      loadVideoById: vi.fn()
+      playVideo: vi.fn()
+    };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    handler.playTrack('vid123');
+    expect(mockApi.playVideo).toHaveBeenCalled();
+    expect(mockApi.loadVideoById).not.toHaveBeenCalled();
+  });
+
+  it('should recognize current videoId when videoData has videoId property', () => {
+    const mockApi = { 
+      loadVideoById: vi.fn(),
+      getVideoData: vi.fn().mockReturnValue({ videoId: 'vid123' }),
+      playVideo: vi.fn()
     };
     const mockApp = document.createElement('ytmusic-app');
     mockApp.playerApi = mockApi;
@@ -74,9 +107,9 @@ describe('PlayerHandler', () => {
 
   it('should call loadVideoById when playTrack is called with different videoId', () => {
     const mockApi = { 
+      loadVideoById: vi.fn(),
       getVideoData: vi.fn().mockReturnValue({ video_id: 'other123' }),
-      playVideo: vi.fn(),
-      loadVideoById: vi.fn()
+      playVideo: vi.fn()
     };
     const mockApp = document.createElement('ytmusic-app');
     mockApp.playerApi = mockApi;
@@ -86,8 +119,26 @@ describe('PlayerHandler', () => {
     expect(mockApi.loadVideoById).toHaveBeenCalledWith('vid123');
   });
 
+  it('should fallback to loadVideoById object when string invocation throws', () => {
+    const loadVideoByIdMock = vi.fn()
+      .mockImplementationOnce(() => { throw new Error('Invalid params'); })
+      .mockImplementationOnce(() => {});
+
+    const mockApi = { 
+      loadVideoById: loadVideoByIdMock,
+      getVideoData: vi.fn().mockReturnValue({ video_id: 'other123' })
+    };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    handler.playTrack('vid123');
+    expect(loadVideoByIdMock).toHaveBeenNthCalledWith(1, 'vid123');
+    expect(loadVideoByIdMock).toHaveBeenNthCalledWith(2, { videoId: 'vid123' });
+  });
+
   it('should call pauseVideo', () => {
-    const mockApi = { pauseVideo: vi.fn() };
+    const mockApi = { loadVideoById: vi.fn(), pauseVideo: vi.fn() };
     const mockApp = document.createElement('ytmusic-app');
     mockApp.playerApi = mockApi;
     document.body.appendChild(mockApp);
@@ -96,14 +147,28 @@ describe('PlayerHandler', () => {
     expect(mockApi.pauseVideo).toHaveBeenCalled();
   });
 
-  it('should call seekBy', () => {
-    const mockApi = { seekBy: vi.fn() };
+  it('should call seekBy when available', () => {
+    const mockApi = { loadVideoById: vi.fn(), seekBy: vi.fn() };
     const mockApp = document.createElement('ytmusic-app');
     mockApp.playerApi = mockApi;
     document.body.appendChild(mockApp);
 
     handler.seekBy(10);
     expect(mockApi.seekBy).toHaveBeenCalledWith(10);
+  });
+
+  it('should fallback to seekTo when seekBy is missing', () => {
+    const mockApi = { 
+      loadVideoById: vi.fn(),
+      seekTo: vi.fn(),
+      getCurrentTime: vi.fn().mockReturnValue(30)
+    };
+    const mockApp = document.createElement('ytmusic-app');
+    mockApp.playerApi = mockApi;
+    document.body.appendChild(mockApp);
+
+    handler.seekBy(10);
+    expect(mockApi.seekTo).toHaveBeenCalledWith(40, true);
   });
 
   it('should return video data', () => {
@@ -303,6 +368,93 @@ describe('PlayerHandler', () => {
       handler.activeSource = CONSTANTS.PLAYER.SOURCE.LOCAL;
       handler.localPlayer = null;
       expect(handler.getPlayerState()).toBe(CONSTANTS.PLAYER.STATE.UNSTARTED);
+    });
+  });
+
+  describe('updatePlayerBar', () => {
+    it('should update thumbnail, title, and artist on player bar element', () => {
+      const playerBar = document.createElement('ytmusic-player-bar');
+      playerBar.innerHTML = `
+        <div class="thumbnail-image-wrapper">
+          <img src="old-thumb.jpg" />
+        </div>
+        <div class="title">
+          <a href="#">Old Title</a>
+        </div>
+        <div class="byline">
+          <a href="#">Old Artist</a>
+        </div>
+      `;
+      playerBar.currentVideoData = {};
+      document.body.appendChild(playerBar);
+
+      handler.updatePlayerBar('newVid123', {
+        name: 'New Track Title',
+        artist: 'New Artist Name',
+        thumbnail: 'http://example.com/new-thumb.jpg'
+      });
+
+      const img = playerBar.querySelector('img');
+      const titleLink = playerBar.querySelector('.title a');
+      const bylineLink = playerBar.querySelector('.byline a');
+
+      expect(img.src).toBe('http://example.com/new-thumb.jpg');
+      expect(titleLink.textContent).toBe('New Track Title');
+      expect(bylineLink.textContent).toBe('New Artist Name');
+      expect(playerBar.currentVideoData.title).toBe('New Track Title');
+    });
+
+    it('should handle player bar with no trackInfo by falling back to videoId default thumbnail and videoData', () => {
+      const playerBar = document.createElement('ytmusic-player-bar');
+      playerBar.innerHTML = `
+        <div class="thumbnail-image-wrapper">
+          <img src="" />
+        </div>
+        <div class="title">Old Title</div>
+        <div class="byline">Old Artist</div>
+      `;
+      document.body.appendChild(playerBar);
+
+      const mockApi = {
+        loadVideoById: vi.fn(),
+        getVideoData: vi.fn().mockReturnValue({ title: 'API Song', author: 'API Artist' })
+      };
+      const mockApp = document.createElement('ytmusic-app');
+      mockApp.playerApi = mockApi;
+      document.body.appendChild(mockApp);
+
+      handler.updatePlayerBar('abc1234');
+
+      const img = playerBar.querySelector('img');
+      const titleEl = playerBar.querySelector('.title');
+      const bylineEl = playerBar.querySelector('.byline');
+
+      expect(img.src).toContain('https://i.ytimg.com/vi/abc1234/hqdefault.jpg');
+      expect(titleEl.textContent).toBe('API Song');
+      expect(bylineEl.textContent).toBe('API Artist');
+    });
+
+    it('should unhide hidden playerBar and hidden parent container', () => {
+      const parent = document.createElement('div');
+      parent.setAttribute('hidden', '');
+      parent.style.display = 'none';
+
+      const playerBar = document.createElement('ytmusic-player-bar');
+      playerBar.setAttribute('hidden', '');
+      playerBar.classList.add('hidden');
+      playerBar.style.display = 'none';
+
+      parent.appendChild(playerBar);
+      document.body.appendChild(parent);
+
+      handler.showPlayerBar();
+
+      expect(playerBar.hasAttribute('hidden')).toBe(false);
+      expect(playerBar.classList.contains('hidden')).toBe(false);
+      expect(playerBar.style.display).not.toBe('none');
+
+      expect(parent.hasAttribute('hidden')).toBe(false);
+      expect(parent.style.display).not.toBe('none');
     });
   });
 });

--- a/tests/utils/ui-components.test.js
+++ b/tests/utils/ui-components.test.js
@@ -57,7 +57,7 @@ describe('UI Components', () => {
 
       // Play click
       playBtn.dispatchEvent(new MouseEvent('click'));
-      expect(playerHandler.playTrack).toHaveBeenCalledWith('v123');
+      expect(playerHandler.playTrack).toHaveBeenCalledWith('v123', media);
       expect(playBtn.classList.contains('yt-music-plus-hidden')).toBe(true);
       expect(pauseBtn.classList.contains('yt-music-plus-hidden')).toBe(false);
 

--- a/tests/utils/ui-helper.test.js
+++ b/tests/utils/ui-helper.test.js
@@ -182,7 +182,7 @@ describe('UIHelper', () => {
        const el = MediaItem.render(media, playerHandler);
        const playBtn = el.querySelector('.yt-music-plus-btn-play');
        playBtn.click();
-       expect(playerHandler.playTrack).toHaveBeenCalledWith('v1');
+       expect(playerHandler.playTrack).toHaveBeenCalledWith('v1', media);
     });
 
     it('should stop propagation on play button click', () => {
@@ -374,14 +374,20 @@ describe('UIHelper', () => {
   });
 
   describe('UIHelper Grid Operations', () => {
-    it('createMediaGridRows should populate container', () => {
+    it('createMediaGridRows should populate container and attach player controls if playerHandler is passed', () => {
+      const mockPlayerHandler = {
+        playTrack: vi.fn(),
+        getVideoData: vi.fn(),
+        getPlayerState: vi.fn()
+      };
       const records = [
-        { originalMedia: { name: 'O1' }, replacementMedia: { name: 'R1' } },
+        { originalMedia: { name: 'O1', videoId: 'v1' }, replacementMedia: { name: 'R1' } },
         { originalMedia: { name: 'O2' }, replacementMedia: { name: 'R2' } }
       ];
-      UIHelper.createMediaGridRows(records);
+      UIHelper.createMediaGridRows(records, 'yt-music-plus-itemsGridContainer', mockPlayerHandler);
       const container = document.getElementById('yt-music-plus-itemsGridContainer');
       expect(container.querySelectorAll('.yt-music-plus-grid-row')).toHaveLength(2);
+      expect(container.querySelector('.yt-music-plus-controls')).not.toBeNull();
     });
 
     it('createMediaGridRows should return null if container not found', () => {

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -219,7 +219,7 @@ export const CONSTANTS = {
   STORAGE_KEYS: {
     // Add storage keys here if needed
   },
-  VERSION: '1.8.0',
+  VERSION: '1.9.0',
   MESSAGE_TYPES: {
     EXT_SETTINGS: 'EXT_SETTINGS',
   }

--- a/utils/ui-helper.js
+++ b/utils/ui-helper.js
@@ -58,7 +58,8 @@ export class MediaItem {
         } else if (media.videoId) {
           const currentVideoData = playerHandler.getVideoData();
           const playerState = playerHandler.getPlayerState();
-          const isCurrentTrack = currentVideoData && currentVideoData.video_id === media.videoId;
+          const currentVideoId = currentVideoData?.video_id || currentVideoData?.videoId;
+          const isCurrentTrack = currentVideoData && currentVideoId === media.videoId;
           
           // Use an array for active playback states to improve scalability
           const activeStates = [
@@ -76,7 +77,7 @@ export class MediaItem {
         if (media.localFile) {
           playerHandler.playLocalFile(media.localFile);
         } else {
-          playerHandler.playTrack(media.videoId);
+          playerHandler.playTrack(media.videoId, media);
         }
         
         // Immediate optimistic update
@@ -322,7 +323,7 @@ export class UIHelper {
   /**
    * Populate a grid container with rows.
    */
-  static createMediaGridRows(records, containerId = CONSTANTS.UI.ELEMENT_IDS.ITEMS_GRID_CONTAINER) {
+  static createMediaGridRows(records, containerId = CONSTANTS.UI.ELEMENT_IDS.ITEMS_GRID_CONTAINER, playerHandler = null) {
     const container = document.getElementById(containerId);
     if (!container) return null;
 
@@ -333,7 +334,8 @@ export class UIHelper {
         MediaGridRow.render(
           record.originalMedia,
           record.replacementMedia,
-          index + 1
+          index + 1,
+          playerHandler
         )
       );
     });


### PR DESCRIPTION
## Summary of Changes
- **Player API Fallbacks**: Enhanced `PlayerHandler.api` to dynamically detect player instances across candidate elements (`ytmusic-app.playerApi`, `#movie_player`, `ytmusic-player-bar`).
- **Resilient Playback Controls**:
  - Supported parameter object fallbacks (`loadVideoById({ videoId })`) and metadata matching for both `video_id` and `videoId`.
  - Added `seekTo` fallback when `seekBy` is unavailable on player instances.
- **Player Bar & Unhiding Synchronization**:
  - Implemented `updatePlayerBar` to sync thumbnail, track title, and artist name on `<ytmusic-player-bar>`.
  - Added `showPlayerBar` to automatically unhide `<ytmusic-player-bar>` and its parent containers when track playback is initiated.
- **Grid Controls Wiring**: Passed `playerHandler` to `createMediaGridRows` and `MediaItem.render`.
- **Version Bump**: Bumped version to `1.9.0` across `package.json`, `manifest.json`, and `utils/constants.js`.
- **Tests & Docs**: Updated unit tests (521 passed) and `FEATURES.md`.